### PR TITLE
Fixing mass migration

### DIFF
--- a/contracts/MassMigrations.sol
+++ b/contracts/MassMigrations.sol
@@ -11,7 +11,6 @@ contract MassMigration {
     using SafeMath for uint256;
     using Tx for bytes;
     using Types for Types.UserState;
-    uint256 constant BURN_STATE_INDEX = 0;
 
     /**
      * @notice processes the state transition of a commitment
@@ -32,18 +31,6 @@ contract MassMigration {
 
         for (uint256 i = 0; i < length; i++) {
             _tx = commitmentBody.txs.massMigration_decode(i);
-
-            // ensure the transaction is to burn state
-            if (_tx.toIndex != BURN_STATE_INDEX) {
-                break;
-            }
-
-            if (i == 0) {
-                metaInfoCounters[3] = _tx.spokeID;
-            } else if (metaInfoCounters[3] != _tx.spokeID) {
-                // commitment should have same spokeID, slash
-                break;
-            }
 
             // aggregate amounts from all transactions
             metaInfoCounters[2] += _tx.amount;

--- a/contracts/MassMigrations.sol
+++ b/contracts/MassMigrations.sol
@@ -24,16 +24,10 @@ contract MassMigration {
     ) public view returns (bytes32, Types.Result result) {
         uint256 length = commitmentBody.txs.massMigration_size();
         Tx.MassMigration memory _tx;
-        uint256 sumAmount = 0;
+        uint256 totalAmount = 0;
 
         for (uint256 i = 0; i < length; i++) {
             _tx = commitmentBody.txs.massMigration_decode(i);
-
-            // aggregate amounts from all transactions
-            sumAmount += _tx.amount;
-
-            // call process tx update for every transaction to check if any
-            // tx evaluates correctly
             (stateRoot, , result) = processMassMigrationTx(
                 stateRoot,
                 _tx,
@@ -46,9 +40,11 @@ contract MassMigration {
             if (result != Types.Result.Ok) {
                 break;
             }
+            // Only trust the amount when the result is good
+            totalAmount += _tx.amount;
         }
 
-        if (sumAmount != commitmentBody.amount) {
+        if (totalAmount != commitmentBody.amount) {
             return (stateRoot, Types.Result.MismatchedAmount);
         }
 

--- a/contracts/Rollup.sol
+++ b/contracts/Rollup.sol
@@ -557,12 +557,13 @@ contract Rollup is RollupHelpers {
             "Commitment not present in batch"
         );
 
-        Types.Result result = transfer.checkSignature(
+        Types.Result result = massMigration.checkSignature(
             target.commitment.body.signature,
             signatureProof,
             target.commitment.stateRoot,
             target.commitment.body.accountRoot,
             APP_ID,
+            target.commitment.body.targetSpokeID,
             target.commitment.body.txs
         );
 

--- a/contracts/libs/Tx.sol
+++ b/contracts/libs/Tx.sol
@@ -467,8 +467,8 @@ library Tx {
             abi.encodePacked(
                 uint8(MASS_MIGRATION),
                 uint32(_tx.fromIndex),
-                uint16(_tx.amount),
-                uint16(_tx.fee),
+                _tx.amount,
+                _tx.fee,
                 uint32(nonce),
                 uint32(spokeID)
             );

--- a/contracts/libs/Types.sol
+++ b/contracts/libs/Types.sol
@@ -219,6 +219,7 @@ library Types {
         BadFromIndex,
         NotOnDesignatedStateLeaf,
         BadSignature,
-        MismatchedAmount
+        MismatchedAmount,
+        BadWithdrawRoot
     }
 }

--- a/contracts/test/TestMassMigration.sol
+++ b/contracts/test/TestMassMigration.sol
@@ -1,0 +1,56 @@
+pragma solidity ^0.5.15;
+pragma experimental ABIEncoderV2;
+
+import { MassMigrationCore } from "../MassMigrations.sol";
+import { MerkleTreeUtils } from "../MerkleTreeUtils.sol";
+import { Types } from "../libs/Types.sol";
+
+contract TestMassMigration is MassMigrationCore {
+    constructor(MerkleTreeUtils _merkleTree) public {
+        merkleTree = _merkleTree;
+    }
+
+    function testCheckSignature(
+        uint256[2] memory signature,
+        Types.SignatureProof memory proof,
+        bytes32 stateRoot,
+        bytes32 accountRoot,
+        bytes32 domain,
+        uint256 targetSpokeID,
+        bytes memory txs
+    ) public view returns (uint256 gasCost, Types.Result result) {
+        gasCost = gasleft();
+        result = checkSignature(
+            signature,
+            proof,
+            stateRoot,
+            accountRoot,
+            domain,
+            targetSpokeID,
+            txs
+        );
+        gasCost = gasCost - gasleft();
+    }
+
+    function testProcessMassMigrationCommit(
+        bytes32 stateRoot,
+        Types.MassMigrationBody memory commitmentBody,
+        Types.StateMerkleProof[] memory proofs
+    )
+        public
+        view
+        returns (
+            uint256 gasCost,
+            bytes32,
+            Types.Result
+        )
+    {
+        gasCost = gasleft();
+        (bytes32 postRoot, Types.Result result) = processMassMigrationCommit(
+            stateRoot,
+            commitmentBody,
+            proofs
+        );
+        return (gasCost - gasleft(), postRoot, result);
+    }
+}

--- a/contracts/test/TestTx.sol
+++ b/contracts/test/TestTx.sol
@@ -130,4 +130,12 @@ contract TestTx {
     {
         return txs.massMigration_size();
     }
+
+    function testMassMigration_messageOf(
+        Tx.MassMigration memory _tx,
+        uint256 nonce,
+        uint256 spokeID
+    ) public pure returns (bytes memory) {
+        return Tx.massMigration_messageOf(_tx, nonce, spokeID);
+    }
 }

--- a/test/MassMigration.test.ts
+++ b/test/MassMigration.test.ts
@@ -81,10 +81,12 @@ describe("Mass Migrations", async function() {
         const aggregatedSignature0 = mcl.g1ToHex(signature);
         const root = await registry.root();
 
-        const leaf = solidityKeccak256(
-            ["uint256", "uint256"],
-            [Alice.pubkeyIndex, tx.amount]
-        );
+        const leaf = State.new(
+            Alice.pubkeyIndex,
+            tokenID,
+            tx.amount,
+            0
+        ).toStateLeaf();
         const withdrawRoot = Tree.merklize([leaf]).root;
 
         const commitment = MassMigrationCommitment.new(

--- a/test/MassMigration.test.ts
+++ b/test/MassMigration.test.ts
@@ -11,6 +11,9 @@ import { assert } from "chai";
 import { MassMigrationBatch, MassMigrationCommitment } from "../ts/commitments";
 import { USDT } from "../ts/decimal";
 import { Result } from "../ts/interfaces";
+import { solidityKeccak256 } from "ethers/lib/utils";
+import { Tree } from "../ts/tree";
+import { getMerkleRootFromLeaves } from "../ts/utils";
 
 const DOMAIN =
     "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
@@ -78,12 +81,18 @@ describe("Mass Migrations", async function() {
         const aggregatedSignature0 = mcl.g1ToHex(signature);
         const root = await registry.root();
 
+        const leaf = solidityKeccak256(
+            ["uint256", "uint256"],
+            [Alice.pubkeyIndex, tx.amount]
+        );
+        const withdrawRoot = Tree.merklize([leaf]).root;
+
         const commitment = MassMigrationCommitment.new(
             stateRoot,
             root,
             aggregatedSignature0,
             tx.spokeID,
-            ethers.constants.HashZero,
+            withdrawRoot,
             tokenID,
             tx.amount,
             txs

--- a/test/MassMigration.test.ts
+++ b/test/MassMigration.test.ts
@@ -63,7 +63,6 @@ describe("Mass Migrations", async function() {
     it("submit a batch and dispute", async function() {
         const tx = new TxMassMigration(
             Alice.stateID,
-            0,
             USDT.castInt(39.99),
             1,
             USDT.castInt(0.01),
@@ -107,7 +106,7 @@ describe("Mass Migrations", async function() {
             stateTree.root,
             "should have same state root"
         );
-        assert.equal(result, Result.Ok, "Should be a safe state transition");
+        assert.equal(result, Result.Ok, `Got ${Result[result]}`);
         commitment.stateRoot = postStateRoot;
 
         const targetBatch = commitment.toBatch();

--- a/test/rollupMassMigration.test.ts
+++ b/test/rollupMassMigration.test.ts
@@ -1,0 +1,105 @@
+import { ethers } from "@nomiclabs/buidler";
+import { AccountRegistry } from "../ts/accountTree";
+import { txMassMigrationFactory, UserStateFactory } from "../ts/factory";
+import { State } from "../ts/state";
+import { StateTree } from "../ts/stateTree";
+import { randHex } from "../ts/utils";
+import {
+    LoggerFactory,
+    BlsAccountRegistryFactory,
+    TestMassMigrationFactory,
+    MerkleTreeUtilsFactory
+} from "../types/ethers-contracts";
+import * as mcl from "../ts/mcl";
+import { TestMassMigration } from "../types/ethers-contracts/TestMassMigration";
+import { serialize } from "../ts/tx";
+import { assert } from "chai";
+import { Result } from "../ts/interfaces";
+
+const DOMAIN_HEX = randHex(32);
+const STATE_SIZE = 32;
+const COMMIT_SIZE = 32;
+const STATE_TREE_DEPTH = 32;
+const spokeID = 1;
+
+describe("Rollup Mass Migration", () => {
+    let rollup: TestMassMigration;
+    let registry: AccountRegistry;
+    let stateTree: StateTree;
+    let states: State[] = [];
+
+    before(async function() {
+        await mcl.init();
+        mcl.setDomainHex(DOMAIN_HEX);
+        const [signer] = await ethers.getSigners();
+        const logger = await new LoggerFactory(signer).deploy();
+        const registryContract = await new BlsAccountRegistryFactory(
+            signer
+        ).deploy(logger.address);
+
+        registry = await AccountRegistry.new(registryContract);
+        states = UserStateFactory.buildList(STATE_SIZE);
+        for (const state of states) {
+            await registry.register(state.getPubkey());
+        }
+    });
+    beforeEach(async function() {
+        const [signer] = await ethers.getSigners();
+        const merkleTree = await new MerkleTreeUtilsFactory(signer).deploy(
+            STATE_TREE_DEPTH
+        );
+        rollup = await new TestMassMigrationFactory(signer).deploy(
+            merkleTree.address
+        );
+        stateTree = StateTree.new(STATE_TREE_DEPTH);
+        stateTree.createStateBulk(states);
+    });
+
+    it("checks signature", async function() {
+        const txs = txMassMigrationFactory(states, COMMIT_SIZE, spokeID);
+        const signatures = [];
+        const pubkeys = [];
+        const pubkeyWitnesses = [];
+
+        for (const tx of txs) {
+            const sender = states[tx.fromIndex];
+            pubkeys.push(sender.getPubkey());
+            pubkeyWitnesses.push(registry.witness(sender.pubkeyIndex));
+            signatures.push(sender.sign(tx));
+        }
+        const signature = mcl.aggreagate(signatures);
+        const { safe } = stateTree.applyMassMigrationBatch(txs);
+        assert.isTrue(safe);
+        const serialized = serialize(txs);
+
+        // Need post stateWitnesses
+        const postStates = txs.map(tx => stateTree.getState(tx.fromIndex));
+        const stateWitnesses = txs.map(tx =>
+            stateTree.getStateWitness(tx.fromIndex)
+        );
+
+        const postStateRoot = stateTree.root;
+        const accountRoot = registry.root();
+
+        const proof = {
+            states: postStates,
+            stateWitnesses,
+            pubkeys,
+            pubkeyWitnesses
+        };
+        const {
+            0: gasCost,
+            1: result
+        } = await rollup.callStatic.testCheckSignature(
+            signature,
+            proof,
+            postStateRoot,
+            accountRoot,
+            DOMAIN_HEX,
+            spokeID,
+            serialized
+        );
+        assert.equal(result, Result.Ok, `Got ${Result[result]}`);
+        console.log("operation gas cost:", gasCost.toString());
+    }).timeout(400000);
+});

--- a/test/rollupMassMigration.test.ts
+++ b/test/rollupMassMigration.test.ts
@@ -113,12 +113,15 @@ describe("Rollup Mass Migration", () => {
         const { proofs, safe } = stateTree.applyMassMigrationBatch(txs);
         assert.isTrue(safe, "Should be a valid applyTransferBatch");
         const postStateRoot = stateTree.root;
+        const tokenID = states[0].tokenType;
 
         const leaves = txs.map(tx =>
-            solidityKeccak256(
-                ["uint256", "uint256"],
-                [states[tx.fromIndex].pubkeyIndex, tx.amount]
-            )
+            State.new(
+                states[tx.fromIndex].pubkeyIndex,
+                tokenID,
+                tx.amount,
+                0
+            ).toStateLeaf()
         );
         const withdrawRoot = Tree.merklize(leaves).root;
         const commitmentBody = {
@@ -126,7 +129,7 @@ describe("Rollup Mass Migration", () => {
             signature: [0, 0],
             targetSpokeID: spokeID,
             withdrawRoot,
-            tokenID: states[0].tokenType,
+            tokenID,
             amount: sum(txs.map(tx => tx.amount)),
             txs: serialize(txs)
         };

--- a/test/txSerialization.test.ts
+++ b/test/txSerialization.test.ts
@@ -134,18 +134,23 @@ describe("Tx Serialization", async () => {
         const size = await c.massMigration_size(serialized);
         assert.equal(size.toNumber(), txs.length);
         for (let i in txs) {
-            const {
-                fromIndex,
-                toIndex,
-                amount,
-                spokeID,
-                fee
-            } = await c.massMigration_decode(serialized, i);
+            const { fromIndex, amount, fee } = await c.massMigration_decode(
+                serialized,
+                i
+            );
             assert.equal(fromIndex.toString(), txs[i].fromIndex.toString());
-            assert.equal(toIndex.toString(), txs[i].toIndex.toString());
             assert.equal(amount.toString(), txs[i].amount.toString());
-            assert.equal(spokeID.toString(), txs[i].spokeID.toString());
             assert.equal(fee.toString(), txs[i].fee.toString());
+            const message = await c.testMassMigration_messageOf(
+                txs[i],
+                txs[i].nonce,
+                txs[i].spokeID
+            );
+            assert.equal(
+                message,
+                txs[i].message(),
+                "message should be the same"
+            );
         }
     });
 });

--- a/ts/commitments.ts
+++ b/ts/commitments.ts
@@ -1,7 +1,6 @@
 import { BigNumberish, BytesLike, ethers } from "ethers";
 import { Rollup } from "../types/ethers-contracts/Rollup";
-import { ZERO_BYTES32 } from "./constants";
-import { Hasher, Tree } from "./tree";
+import { Tree } from "./tree";
 
 interface CompressedStruct {
     stateRoot: BytesLike;
@@ -180,11 +179,7 @@ export class MassMigrationCommitment extends Commitment {
 export class Batch {
     private tree: Tree;
     constructor(public readonly commitments: Commitment[]) {
-        const depth = Math.ceil(Math.log2(commitments.length + 1));
-        this.tree = Tree.new(depth, Hasher.new("bytes", ZERO_BYTES32));
-        for (const [index, commitment] of commitments.entries()) {
-            this.tree.updateSingle(index, commitment.hash());
-        }
+        this.tree = Tree.merklize(commitments.map(c => c.hash()));
     }
 
     get commitmentRoot(): string {

--- a/ts/deploy.ts
+++ b/ts/deploy.ts
@@ -130,7 +130,10 @@ export async function deployAll(
         await paramManager.VAULT()
     );
 
-    const massMigration = await new MassMigrationFactory(signer).deploy();
+    const massMigration = await new MassMigrationFactory(
+        allLinkRefs,
+        signer
+    ).deploy(nameRegistry.address);
     await waitAndRegister(
         massMigration,
         "mass_migs",

--- a/ts/factory.ts
+++ b/ts/factory.ts
@@ -2,7 +2,7 @@ import { BigNumber } from "ethers";
 import { COMMIT_SIZE } from "./constants";
 import { USDT } from "./decimal";
 import { State } from "./state";
-import { TxTransfer, TxCreate2Transfer } from "./tx";
+import { TxTransfer, TxCreate2Transfer, TxMassMigration } from "./tx";
 
 export class UserStateFactory {
     public static buildList(
@@ -82,8 +82,31 @@ export function txCreate2TransferFactory(
             fee,
             sender.nonce,
             USDT
-        );
+        );     
+        txs.push(tx);
+    }
+    return txs;
+}
 
+export function txMassMigrationFactory(
+    states: State[],
+    n: number = COMMIT_SIZE,
+    spokeID = 0
+): TxMassMigration[] {
+    const txs: TxMassMigration[] = [];
+    for (let i = 0; i < n; i++) {
+        const senderIndex = i;
+        const sender = states[senderIndex];
+        const amount = sender.balance.div(10);
+        const fee = amount.div(10);
+        const tx = new TxMassMigration(
+            senderIndex,
+            amount,
+            spokeID,
+            fee,
+            sender.nonce,
+            USDT
+        );
         txs.push(tx);
     }
     return txs;

--- a/ts/factory.ts
+++ b/ts/factory.ts
@@ -82,7 +82,7 @@ export function txCreate2TransferFactory(
             fee,
             sender.nonce,
             USDT
-        );     
+        );
         txs.push(tx);
     }
     return txs;

--- a/ts/interfaces.ts
+++ b/ts/interfaces.ts
@@ -21,5 +21,6 @@ export enum Result {
     BadFromIndex,
     NotOnDesignatedStateLeaf,
     BadSignature,
-    MismatchedAmount
+    MismatchedAmount,
+    BadWithdrawRoot
 }

--- a/ts/tree/tree.ts
+++ b/ts/tree/tree.ts
@@ -1,3 +1,4 @@
+import { ZERO_BYTES32 } from "../constants";
 import { Hasher, Node } from "./hasher";
 
 type Level = { [node: number]: Node };
@@ -22,6 +23,18 @@ export class Tree {
 
     public static new(depth: number, hasher?: Hasher): Tree {
         return new Tree(depth, hasher || Hasher.new());
+    }
+
+    public static merklize(leaves: Node[]): Tree {
+        // Make the depth as shallow as possible
+        // the length 1 is a special case that the formula doesn't work
+        const depth =
+            leaves.length == 1 ? 1 : Math.ceil(Math.log2(leaves.length));
+        // This ZERO_BYTES32 must match the one we use in the mekle tree utils contract
+        const hasher = Hasher.new("bytes", ZERO_BYTES32);
+        const tree = Tree.new(depth, hasher);
+        tree.updateBatch(0, leaves);
+        return tree;
     }
 
     constructor(depth: number, hasher: Hasher) {

--- a/ts/tx.ts
+++ b/ts/tx.ts
@@ -2,13 +2,7 @@ import { BigNumber } from "ethers";
 import { randomNum } from "./utils";
 import { DecimalCodec, USDT } from "./decimal";
 import { MismatchByteLength } from "./exceptions";
-import {
-    hexZeroPad,
-    concat,
-    hexlify,
-    solidityKeccak256,
-    solidityPack
-} from "ethers/lib/utils";
+import { hexZeroPad, concat, hexlify, solidityPack } from "ethers/lib/utils";
 import { COMMIT_SIZE } from "./constants";
 
 const amountLen = 2;
@@ -138,15 +132,17 @@ export class TxMassMigration implements SignableTx {
     }
 
     public message(): string {
-        const concated = concat([
-            this.TX_TYPE,
-            hexZeroPad(hexlify(this.fromIndex), stateIDLen),
-            hexZeroPad(this.amount.toHexString(), 32),
-            hexZeroPad(this.fee.toHexString(), 32),
-            hexZeroPad(hexlify(this.nonce), nonceLen),
-            hexZeroPad(hexlify(this.spokeID), spokeLen)
-        ]);
-        return hexlify(concated);
+        return solidityPack(
+            ["uint8", "uint32", "uint256", "uint256", "uint32", "uint32"],
+            [
+                this.TX_TYPE,
+                this.fromIndex,
+                this.amount,
+                this.fee,
+                this.nonce,
+                this.spokeID
+            ]
+        );
     }
 
     public extended() {

--- a/ts/tx.ts
+++ b/ts/tx.ts
@@ -109,23 +109,14 @@ export class TxTransfer implements SignableTx {
 }
 
 export class TxMassMigration implements SignableTx {
-    private readonly TX_TYPE = "0x06";
+    private readonly TX_TYPE = "0x05";
     public static rand(): TxMassMigration {
         const sender = randomNum(stateIDLen);
-        const receiver = randomNum(stateIDLen);
         const amount = USDT.randInt();
         const fee = USDT.randInt();
         const nonce = randomNum(nonceLen);
         const spokeID = randomNum(spokeLen);
-        return new TxMassMigration(
-            sender,
-            receiver,
-            amount,
-            spokeID,
-            fee,
-            nonce,
-            USDT
-        );
+        return new TxMassMigration(sender, amount, spokeID, fee, nonce, USDT);
     }
     public static buildList(n: number = COMMIT_SIZE): TxMassMigration[] {
         const txs = [];
@@ -136,7 +127,6 @@ export class TxMassMigration implements SignableTx {
     }
     constructor(
         public readonly fromIndex: number,
-        public readonly toIndex: number,
         public readonly amount: BigNumber,
         public readonly spokeID: number,
         public readonly fee: BigNumber,
@@ -150,8 +140,11 @@ export class TxMassMigration implements SignableTx {
     public message(): string {
         const concated = concat([
             this.TX_TYPE,
+            hexZeroPad(hexlify(this.fromIndex), stateIDLen),
+            hexZeroPad(this.amount.toHexString(), 32),
+            hexZeroPad(this.fee.toHexString(), 32),
             hexZeroPad(hexlify(this.nonce), nonceLen),
-            this.encode()
+            hexZeroPad(hexlify(this.spokeID), spokeLen)
         ]);
         return hexlify(concated);
     }
@@ -159,7 +152,6 @@ export class TxMassMigration implements SignableTx {
     public extended() {
         return {
             fromIndex: this.fromIndex,
-            toIndex: this.toIndex,
             amount: this.amount,
             spokeID: this.spokeID,
             fee: this.fee,
@@ -171,9 +163,7 @@ export class TxMassMigration implements SignableTx {
     public encode(): string {
         const concated = concat([
             hexZeroPad(hexlify(this.fromIndex), stateIDLen),
-            hexZeroPad(hexlify(this.toIndex), stateIDLen),
             this.decimal.encodeInt(this.amount),
-            hexZeroPad(hexlify(this.spokeID), spokeLen),
             this.decimal.encodeInt(this.fee)
         ]);
         return hexlify(concated);

--- a/ts/utils.ts
+++ b/ts/utils.ts
@@ -14,6 +14,10 @@ export function randHex(n: number): string {
     return hexlify(randomBytes(n));
 }
 
+export function sum(xs: BigNumber[]): BigNumber {
+    return xs.reduce((a, b) => a.add(b));
+}
+
 export function to32Hex(n: BigNumber): string {
     return hexZeroPad(n.toHexString(), 32);
 }


### PR DESCRIPTION
Some summary of the discussion today:

- no point checking spokeID in state transition, we should check it in dispute signature
- no point checking BURN_STATE_INDEX in the state transition, since we don't modify the receiver state
- no point checking tx.tokenType all equal, check them against the committed tokenType instead.