### PR TITLE
Fix submit deposit batch

### DIFF
--- a/contracts/DepositManager.sol
+++ b/contracts/DepositManager.sol
@@ -2,7 +2,6 @@ pragma solidity ^0.5.15;
 pragma experimental ABIEncoderV2;
 import { Types } from "./libs/Types.sol";
 import { Logger } from "./Logger.sol";
-import { MerkleTreeUtils as MTUtils } from "./MerkleTreeUtils.sol";
 import { NameRegistry as Registry } from "./NameRegistry.sol";
 import { ITokenRegistry } from "./interfaces/ITokenRegistry.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -91,7 +90,6 @@ contract DepositManager is DepositCore {
     Registry public nameRegistry;
     address public vault;
 
-    MTUtils public merkleUtils;
     Governance public governance;
     Logger public logger;
     ITokenRegistry public tokenRegistry;
@@ -120,9 +118,6 @@ contract DepositManager is DepositCore {
         nameRegistry = Registry(_registryAddr);
         governance = Governance(
             nameRegistry.getContractDetails(ParamManager.Governance())
-        );
-        merkleUtils = MTUtils(
-            nameRegistry.getContractDetails(ParamManager.MERKLE_UTILS())
         );
         tokenRegistry = ITokenRegistry(
             nameRegistry.getContractDetails(ParamManager.TOKEN_REGISTRY())

--- a/contracts/DepositManager.sol
+++ b/contracts/DepositManager.sol
@@ -183,6 +183,7 @@ contract DepositManager is DepositCore {
         bytes32 subtreeRoot = submittedSubtree[batchID];
         if (subtreeRoot != bytes32(0)) {
             enqueue(subtreeRoot);
+            delete submittedSubtree[batchID];
         }
     }
 }

--- a/contracts/DepositManager.sol
+++ b/contracts/DepositManager.sol
@@ -171,38 +171,12 @@ contract DepositManager is DepositCore {
         }
     }
 
-    /**
-     * @notice Merges the deposit tree with the balance tree by
-     *        superimposing the deposit subtree on the balance tree
-     * @param _subTreeDepth Deposit tree depth or depth of subtree that is being deposited
-     * @param zero Merkle proof proving the node at which we are inserting the deposit subtree consists of all empty leaves
-     * @return Updates in-state merkle tree root
-     */
-    function finaliseDeposits(
-        uint256 _subTreeDepth,
-        Types.StateMerkleProofWithPath memory zero,
-        bytes32 latestBalanceTree
-    ) public onlyRollup returns (bytes32) {
-        bytes32 emptySubtreeRoot = merkleUtils.getRoot(_subTreeDepth);
-
-        require(
-            merkleUtils.verifyLeaf(
-                latestBalanceTree,
-                emptySubtreeRoot,
-                zero.path,
-                zero.witness
-            ),
-            "proof invalid"
-        );
-
-        // just dequeue from the pre package deposit subtrees
-        bytes32 depositsSubTreeRoot = dequeue();
-
-        // emit the event
-        logger.logDepositFinalised(depositsSubTreeRoot, zero.path);
-
-        // return the updated merkle tree root
-        return (depositsSubTreeRoot);
+    function finaliseDeposits()
+        public
+        onlyRollup
+        returns (bytes32 subtreeRoot)
+    {
+        subtreeRoot = dequeue();
     }
 
     function reenqueue(bytes32 subtreeRoot) external onlyRollup {

--- a/contracts/Rollup.sol
+++ b/contracts/Rollup.sol
@@ -286,7 +286,6 @@ contract Rollup is RollupHelpers {
             ),
             committer: msg.sender,
             finalisesOn: block.number + governance.TIME_TO_FINALISE(),
-            depositRoot: ZERO_BYTES32,
             withdrawn: false
         });
         batches.push(newBatch);
@@ -306,7 +305,6 @@ contract Rollup is RollupHelpers {
             commitmentRoot: merkleUtils.getMerkleRootFromLeaves(commitments),
             committer: msg.sender,
             finalisesOn: block.number + governance.TIME_TO_FINALISE(),
-            depositRoot: ZERO_BYTES32,
             withdrawn: false
         });
         batches.push(newBatch);
@@ -441,7 +439,6 @@ contract Rollup is RollupHelpers {
             ),
             committer: msg.sender,
             finalisesOn: block.number + governance.TIME_TO_FINALISE(),
-            depositRoot: depositSubTreeRoot,
             withdrawn: false
         });
 

--- a/contracts/Rollup.sol
+++ b/contracts/Rollup.sol
@@ -409,11 +409,19 @@ contract Rollup is RollupHelpers {
         uint256 _subTreeDepth,
         Types.StateMerkleProofWithPath calldata zero
     ) external payable onlyCoordinator isNotRollingBack {
-        bytes32 depositSubTreeRoot = depositManager.finaliseDeposits(
-            _subTreeDepth,
-            zero,
-            getLatestBalanceTreeRoot()
+        bytes32 stateRoot = getLatestBalanceTreeRoot();
+        bytes32 emptySubtreeRoot = merkleUtils.getRoot(_subTreeDepth);
+        require(
+            merkleUtils.verifyLeaf(
+                stateRoot,
+                emptySubtreeRoot,
+                zero.path,
+                zero.witness
+            ),
+            "proof invalid"
         );
+        bytes32 depositSubTreeRoot = depositManager.finaliseDeposits();
+        logger.logDepositFinalised(depositSubTreeRoot, zero.path);
 
         bytes32 newRoot = merkleUtils.updateLeafWithSiblings(
             depositSubTreeRoot,

--- a/contracts/Rollup.sol
+++ b/contracts/Rollup.sol
@@ -184,7 +184,7 @@ contract RollupHelpers is RollupSetup {
             delete batches[i];
 
             // queue deposits again
-            depositManager.reenqueue(batch.depositRoot);
+            depositManager.tryReenqueue(i);
 
             totalSlashings++;
 
@@ -420,7 +420,8 @@ contract Rollup is RollupHelpers {
             ),
             "proof invalid"
         );
-        bytes32 depositSubTreeRoot = depositManager.finaliseDeposits();
+        uint256 newBatchID = batches.length;
+        bytes32 depositSubTreeRoot = depositManager.dequeueToSubmit(newBatchID);
         logger.logDepositFinalised(depositSubTreeRoot, zero.path);
 
         bytes32 newRoot = merkleUtils.updateLeafWithSiblings(

--- a/contracts/libs/Types.sol
+++ b/contracts/libs/Types.sol
@@ -208,6 +208,12 @@ library Types {
         bytes32[] witness;
     }
 
+    struct SubtreeVacancyProof {
+        uint256 depth;
+        uint256 pathAtDepth;
+        bytes32[] witness;
+    }
+
     enum Result {
         Ok,
         InvalidTokenAddress,

--- a/contracts/libs/Types.sol
+++ b/contracts/libs/Types.sol
@@ -35,7 +35,6 @@ library Types {
         bytes32 commitmentRoot;
         address committer;
         uint256 finalisesOn;
-        bytes32 depositRoot;
         bool withdrawn;
     }
 


### PR DESCRIPTION
Fix  #181 and some other stuff.

DepositManager now does two things:

- dequeue a subtree and mark it submitted at batchID
- enqueue a subtree if it has been submitted at batchID before

Since DepositManager already trusts Rollup contract, so we move subtree vacancy check to the Rollup contract.

This solves the problem we had:
1. We've been submitting empty deposit roots in every non-deposit Batch. Now we don't need a field in Batch.
2. When rollback the batches, we are enqueuing zero bytes to the queue.