### PR TITLE
Transition: cleaner state transition logic

### DIFF
--- a/contracts/Create2Transfer.sol
+++ b/contracts/Create2Transfer.sol
@@ -91,8 +91,7 @@ contract Create2Transfer {
         uint256 feeReceiver
     ) public pure returns (bytes32, Types.Result result) {
         uint256 length = txs.create2Transfer_size();
-
-        uint256 fees;
+        uint256 fees = 0;
         Tx.Create2Transfer memory _tx;
 
         for (uint256 i = 0; i < length; i++) {
@@ -133,7 +132,7 @@ contract Create2Transfer {
         Types.StateMerkleProof memory from,
         Types.StateMerkleProof memory to
     )
-        public
+        internal
         pure
         returns (
             bytes32 newRoot,
@@ -166,8 +165,8 @@ contract Create2Transfer {
         Tx.Create2Transfer memory _tx,
         uint256 token,
         Types.StateMerkleProof memory proof
-    ) public pure returns (bytes memory encodedState, bytes32 newRoot) {
-        // Validate we are creating on a zero account
+    ) internal pure returns (bytes memory encodedState, bytes32 newRoot) {
+        // Validate we are creating on a zero state
         require(
             MerkleTreeUtilsLib.verifyLeaf(
                 stateRoot,
@@ -177,7 +176,6 @@ contract Create2Transfer {
             ),
             "Create2Transfer: receiver proof invalid"
         );
-        // Initialize account
         Types.UserState memory newState = Types.UserState(
             _tx.toAccID,
             token,

--- a/contracts/Create2Transfer.sol
+++ b/contracts/Create2Transfer.sol
@@ -104,20 +104,17 @@ contract Create2Transfer {
                 proofs[i * 2],
                 proofs[i * 2 + 1]
             );
-            if (result != Types.Result.Ok) break;
+            if (result != Types.Result.Ok) return (stateRoot, result);
             // Only trust fees when the result is good
             fees = fees.add(_tx.fee);
         }
-
-        if (result == Types.Result.Ok) {
-            (stateRoot, , result) = Transition.processReceiver(
-                stateRoot,
-                feeReceiver,
-                fees,
-                tokenType,
-                proofs[length * 2]
-            );
-        }
+        (stateRoot, , result) = Transition.processReceiver(
+            stateRoot,
+            feeReceiver,
+            fees,
+            tokenType,
+            proofs[length * 2]
+        );
 
         return (stateRoot, result);
     }

--- a/contracts/Create2Transfer.sol
+++ b/contracts/Create2Transfer.sol
@@ -155,6 +155,7 @@ contract Create2Transfer {
         );
         if (result != Types.Result.Ok) return (bytes32(0), "", "", result);
         (newToState, newRoot) = processCreate2TransferReceiver(
+            newRoot,
             _tx,
             from.state.tokenType,
             to
@@ -164,6 +165,7 @@ contract Create2Transfer {
     }
 
     function processCreate2TransferReceiver(
+        bytes32 stateRoot,
         Tx.Create2Transfer memory _tx,
         uint256 token,
         Types.StateMerkleProof memory proof
@@ -171,7 +173,7 @@ contract Create2Transfer {
         // Validate we are creating on a zero account
         require(
             MerkleTreeUtilsLib.verifyLeaf(
-                newRoot,
+                stateRoot,
                 keccak256(abi.encode(0)),
                 _tx.toIndex,
                 proof.witness

--- a/contracts/Create2Transfer.sol
+++ b/contracts/Create2Transfer.sol
@@ -81,7 +81,6 @@ contract Create2Transfer {
 
     /**
      * @notice processes the state transition of a commitment
-     * @return updatedRoot, txRoot and if the batch is valid or not
      * */
     function processCreate2TransferCommit(
         bytes32 stateRoot,
@@ -123,7 +122,6 @@ contract Create2Transfer {
      *  and the updated leaves
      * conditions in require mean that the dispute be declared invalid
      * if conditons evaluate if the coordinator was at fault
-     * @return Total number of batches submitted onchain
      */
     function processTx(
         bytes32 stateRoot,

--- a/contracts/MassMigrations.sol
+++ b/contracts/MassMigrations.sol
@@ -116,7 +116,7 @@ contract MassMigrationCore {
         uint256 tokenType,
         Types.StateMerkleProof memory from
     )
-        public
+        internal
         pure
         returns (
             bytes32 newRoot,

--- a/contracts/MassMigrations.sol
+++ b/contracts/MassMigrations.sol
@@ -71,7 +71,6 @@ contract MassMigrationCore {
     /**
      * @notice processes the state transition of a commitment
      * @param stateRoot represents the state before the state transition
-     * @return updatedRoot, txRoot and if the batch is valid or not
      * */
     function processMassMigrationCommit(
         bytes32 stateRoot,

--- a/contracts/MassMigrations.sol
+++ b/contracts/MassMigrations.sol
@@ -99,15 +99,13 @@ contract MassMigrationCore {
             withdrawLeaves[i] = keccak256(freshState);
         }
 
-        if (totalAmount != commitmentBody.amount) {
+        if (totalAmount != commitmentBody.amount)
             return (stateRoot, Types.Result.MismatchedAmount);
-        }
+
         if (
             merkleTree.getMerkleRootFromLeaves(withdrawLeaves) !=
             commitmentBody.withdrawRoot
-        ) {
-            return (stateRoot, Types.Result.BadWithdrawRoot);
-        }
+        ) return (stateRoot, Types.Result.BadWithdrawRoot);
 
         return (stateRoot, result);
     }
@@ -121,14 +119,12 @@ contract MassMigrationCore {
         public
         pure
         returns (
-            bytes32,
-            bytes memory,
+            bytes32 newRoot,
+            bytes memory newFromState,
             bytes memory freshState,
             Types.Result result
         )
     {
-        bytes32 newRoot = bytes32(0);
-        bytes memory newFromState = "";
         (newRoot, newFromState, result) = Transition.processSender(
             stateRoot,
             _tx.fromIndex,

--- a/contracts/MassMigrations.sol
+++ b/contracts/MassMigrations.sol
@@ -127,7 +127,9 @@ contract MassMigrationCore {
             Types.Result result
         )
     {
-        result = Transition.validateSender(
+        bytes32 newRoot = bytes32(0);
+        bytes memory newFromState = "";
+        (newRoot, newFromState, result) = Transition.processSender(
             stateRoot,
             _tx.fromIndex,
             tokenType,
@@ -136,12 +138,6 @@ contract MassMigrationCore {
             from
         );
         if (result != Types.Result.Ok) return (bytes32(0), "", "", result);
-
-        (bytes memory newFromState, bytes32 newRoot) = Transition.ApplySender(
-            from,
-            _tx.fromIndex,
-            _tx.amount.add(_tx.fee)
-        );
 
         Types.UserState memory fresh = Types.UserState({
             pubkeyIndex: from.state.pubkeyIndex,

--- a/contracts/MassMigrations.sol
+++ b/contracts/MassMigrations.sol
@@ -92,7 +92,7 @@ contract MassMigrationCore {
                 commitmentBody.tokenID,
                 proofs[i]
             );
-            if (result != Types.Result.Ok) break;
+            if (result != Types.Result.Ok) return (stateRoot, result);
 
             // Only trust these variables when the result is good
             totalAmount += _tx.amount;

--- a/contracts/MassMigrations.sol
+++ b/contracts/MassMigrations.sol
@@ -130,7 +130,7 @@ contract MassMigrationCore {
             _tx.fromIndex,
             tokenType,
             _tx.amount,
-            _tx.fee,
+            0,
             from
         );
         if (result != Types.Result.Ok) return (bytes32(0), "", "", result);

--- a/contracts/Transfer.sol
+++ b/contracts/Transfer.sol
@@ -88,19 +88,17 @@ contract Transfer {
                 proofs[i * 2],
                 proofs[i * 2 + 1]
             );
-            if (result != Types.Result.Ok) break;
+            if (result != Types.Result.Ok) return (stateRoot, result);
             // Only trust fees when the result is good
             fees = fees.add(_tx.fee);
         }
-        if (result == Types.Result.Ok) {
-            (stateRoot, , result) = Transition.processReceiver(
-                stateRoot,
-                feeReceiver,
-                fees,
-                tokenType,
-                proofs[length * 2]
-            );
-        }
+        (stateRoot, , result) = Transition.processReceiver(
+            stateRoot,
+            feeReceiver,
+            fees,
+            tokenType,
+            proofs[length * 2]
+        );
 
         return (stateRoot, result);
     }

--- a/contracts/Transfer.sol
+++ b/contracts/Transfer.sol
@@ -117,7 +117,7 @@ contract Transfer {
         Types.StateMerkleProof memory from,
         Types.StateMerkleProof memory to
     )
-        public
+        internal
         pure
         returns (
             bytes32 newRoot,

--- a/contracts/Transfer.sol
+++ b/contracts/Transfer.sol
@@ -131,7 +131,10 @@ contract Transfer {
             Types.Result result
         )
     {
-        result = Transition.validateSender(
+        bytes32 newRoot = bytes32(0);
+        bytes memory newFromState = "";
+
+        (newRoot, newFromState, result) = Transition.processSender(
             stateRoot,
             _tx.fromIndex,
             tokenType,
@@ -140,11 +143,6 @@ contract Transfer {
             from
         );
         if (result != Types.Result.Ok) return (bytes32(0), "", "", result);
-        (bytes memory newFromState, bytes32 newRoot) = Transition.ApplySender(
-            from,
-            _tx.fromIndex,
-            _tx.amount.add(_tx.fee)
-        );
         bytes memory newToState = "";
         (newRoot, newToState, result) = Transition.processReceiver(
             newRoot,

--- a/contracts/Transfer.sol
+++ b/contracts/Transfer.sol
@@ -122,15 +122,12 @@ contract Transfer {
         public
         pure
         returns (
-            bytes32,
-            bytes memory,
-            bytes memory,
+            bytes32 newRoot,
+            bytes memory newFromState,
+            bytes memory newToState,
             Types.Result result
         )
     {
-        bytes32 newRoot = bytes32(0);
-        bytes memory newFromState = "";
-
         (newRoot, newFromState, result) = Transition.processSender(
             stateRoot,
             _tx.fromIndex,
@@ -140,7 +137,6 @@ contract Transfer {
             from
         );
         if (result != Types.Result.Ok) return (bytes32(0), "", "", result);
-        bytes memory newToState = "";
         (newRoot, newToState, result) = Transition.processReceiver(
             newRoot,
             _tx.toIndex,

--- a/contracts/Transfer.sol
+++ b/contracts/Transfer.sol
@@ -65,7 +65,6 @@ contract Transfer {
 
     /**
      * @notice processes the state transition of a commitment
-     * @return updatedRoot, txRoot and if the batch is valid or not
      * */
     function processTransferCommit(
         bytes32 stateRoot,
@@ -108,7 +107,6 @@ contract Transfer {
      *  and the updated leaves
      * conditions in require mean that the dispute be declared invalid
      * if conditons evaluate if the coordinator was at fault
-     * @return Total number of batches submitted onchain
      */
     function processTx(
         bytes32 stateRoot,

--- a/contracts/Transfer.sol
+++ b/contracts/Transfer.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.5.15;
 pragma experimental ABIEncoderV2;
 
 import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";
-import { FraudProofHelpers } from "./libs/FraudProofHelpers.sol";
+import { Transition } from "./libs/Transition.sol";
 import { Types } from "./libs/Types.sol";
 import { MerkleTreeUtilsLib } from "./MerkleTreeUtils.sol";
 
@@ -128,83 +128,39 @@ contract Transfer {
             bytes32,
             bytes memory,
             bytes memory,
-            Types.Result
+            Types.Result result
         )
     {
-        require(
-            MerkleTreeUtilsLib.verifyLeaf(
-                stateRoot,
-                keccak256(from.state.encode()),
-                _tx.fromIndex,
-                from.witness
-            ),
-            "Transfer: sender does not exist"
-        );
-
-        Types.Result result = FraudProofHelpers.validateTxBasic(
+        result = Transition.validateSender(
+            stateRoot,
+            _tx.fromIndex,
+            tokenType,
             _tx.amount,
             _tx.fee,
-            from.state
+            from
+        );
+        if (result != Types.Result.Ok) return (bytes32(0), "", "", result);
+        (bytes memory newFromState, bytes32 newRoot) = Transition.ApplySender(
+            from,
+            _tx.fromIndex,
+            _tx.amount.add(_tx.fee)
+        );
+        result = Transition.validateReceiver(
+            newRoot,
+            _tx.toIndex,
+            tokenType,
+            to
         );
         if (result != Types.Result.Ok) return (bytes32(0), "", "", result);
 
-        if (from.state.tokenType != tokenType) {
-            return (bytes32(0), "", "", Types.Result.BadFromTokenType);
-        }
-
-        if (to.state.tokenType != tokenType)
-            return (bytes32(0), "", "", Types.Result.BadToTokenType);
-
-        bytes32 newRoot;
-        bytes memory newFromState;
-        bytes memory newToState;
-
-        (newFromState, newRoot) = ApplyTransferTxSender(from, _tx);
-
-        require(
-            MerkleTreeUtilsLib.verifyLeaf(
-                newRoot,
-                keccak256(to.state.encode()),
-                _tx.toIndex,
-                to.witness
-            ),
-            "Transfer: receiver does not exist"
+        bytes memory newToState = "";
+        (newToState, newRoot) = Transition.ApplyReceiver(
+            to,
+            _tx.toIndex,
+            _tx.amount
         );
-
-        (newToState, newRoot) = ApplyTransferTxReceiver(to, _tx);
 
         return (newRoot, newFromState, newToState, Types.Result.Ok);
-    }
-
-    function ApplyTransferTxSender(
-        Types.StateMerkleProof memory _merkle_proof,
-        Tx.Transfer memory _tx
-    ) public pure returns (bytes memory newState, bytes32 newRoot) {
-        Types.UserState memory state = _merkle_proof.state;
-        state.balance = state.balance.sub(_tx.amount).sub(_tx.fee);
-        state.nonce++;
-        bytes memory encodedState = state.encode();
-        newRoot = MerkleTreeUtilsLib.rootFromWitnesses(
-            keccak256(encodedState),
-            _tx.fromIndex,
-            _merkle_proof.witness
-        );
-        return (encodedState, newRoot);
-    }
-
-    function ApplyTransferTxReceiver(
-        Types.StateMerkleProof memory _merkle_proof,
-        Tx.Transfer memory _tx
-    ) public pure returns (bytes memory newState, bytes32 newRoot) {
-        Types.UserState memory state = _merkle_proof.state;
-        state.balance = state.balance.add(_tx.amount);
-        bytes memory encodedState = state.encode();
-        newRoot = MerkleTreeUtilsLib.rootFromWitnesses(
-            keccak256(encodedState),
-            _tx.toIndex,
-            _merkle_proof.witness
-        );
-        return (encodedState, newRoot);
     }
 
     function processFee(
@@ -212,27 +168,16 @@ contract Transfer {
         uint256 fees,
         uint256 tokenType,
         uint256 feeReceiver,
-        Types.StateMerkleProof memory stateLeafProof
+        Types.StateMerkleProof memory proof
     ) public pure returns (bytes32 newRoot, Types.Result) {
-        Types.UserState memory state = stateLeafProof.state;
-        if (state.tokenType != tokenType) {
-            return (bytes32(0), Types.Result.BadToTokenType);
-        }
-        require(
-            MerkleTreeUtilsLib.verifyLeaf(
-                stateRoot,
-                keccak256(state.encode()),
-                feeReceiver,
-                stateLeafProof.witness
-            ),
-            "Transfer: fee receiver does not exist"
-        );
-        state.balance = state.balance.add(fees);
-        newRoot = MerkleTreeUtilsLib.rootFromWitnesses(
-            keccak256(state.encode()),
+        Types.Result result = Transition.validateReceiver(
+            stateRoot,
             feeReceiver,
-            stateLeafProof.witness
+            tokenType,
+            proof
         );
+        if (result != Types.Result.Ok) return (bytes32(0), result);
+        (, newRoot) = Transition.ApplyReceiver(proof, feeReceiver, fees);
         return (newRoot, Types.Result.Ok);
     }
 }

--- a/contracts/Transfer.sol
+++ b/contracts/Transfer.sol
@@ -96,11 +96,11 @@ contract Transfer {
             }
         }
         if (result == Types.Result.Ok) {
-            (stateRoot, result) = processFee(
+            (stateRoot, , result) = Transition.processReceiver(
                 stateRoot,
+                feeReceiver,
                 fees,
                 tokenType,
-                feeReceiver,
                 proofs[length * 2]
             );
         }
@@ -145,39 +145,14 @@ contract Transfer {
             _tx.fromIndex,
             _tx.amount.add(_tx.fee)
         );
-        result = Transition.validateReceiver(
+        bytes memory newToState = "";
+        (newRoot, newToState, result) = Transition.processReceiver(
             newRoot,
             _tx.toIndex,
+            _tx.amount,
             tokenType,
             to
         );
-        if (result != Types.Result.Ok) return (bytes32(0), "", "", result);
-
-        bytes memory newToState = "";
-        (newToState, newRoot) = Transition.ApplyReceiver(
-            to,
-            _tx.toIndex,
-            _tx.amount
-        );
-
-        return (newRoot, newFromState, newToState, Types.Result.Ok);
-    }
-
-    function processFee(
-        bytes32 stateRoot,
-        uint256 fees,
-        uint256 tokenType,
-        uint256 feeReceiver,
-        Types.StateMerkleProof memory proof
-    ) public pure returns (bytes32 newRoot, Types.Result) {
-        Types.Result result = Transition.validateReceiver(
-            stateRoot,
-            feeReceiver,
-            tokenType,
-            proof
-        );
-        if (result != Types.Result.Ok) return (bytes32(0), result);
-        (, newRoot) = Transition.ApplyReceiver(proof, feeReceiver, fees);
-        return (newRoot, Types.Result.Ok);
+        return (newRoot, newFromState, newToState, result);
     }
 }

--- a/contracts/Transfer.sol
+++ b/contracts/Transfer.sol
@@ -80,10 +80,7 @@ contract Transfer {
         Tx.Transfer memory _tx;
 
         for (uint256 i = 0; i < length; i++) {
-            // call process tx update for every transaction to check if any
-            // tx evaluates correctly
             _tx = txs.transfer_decode(i);
-            fees = fees.add(_tx.fee);
             (stateRoot, , , result) = processTx(
                 stateRoot,
                 _tx,
@@ -91,9 +88,9 @@ contract Transfer {
                 proofs[i * 2],
                 proofs[i * 2 + 1]
             );
-            if (result != Types.Result.Ok) {
-                break;
-            }
+            if (result != Types.Result.Ok) break;
+            // Only trust fees when the result is good
+            fees = fees.add(_tx.fee);
         }
         if (result == Types.Result.Ok) {
             (stateRoot, , result) = Transition.processReceiver(

--- a/contracts/libs/FraudProofHelpers.sol
+++ b/contracts/libs/FraudProofHelpers.sol
@@ -12,12 +12,11 @@ library FraudProofHelpers {
         uint256 fee,
         Types.UserState memory fromState
     ) internal pure returns (Types.Result) {
-        if (amount == 0) {
-            return Types.Result.InvalidTokenAmount;
-        }
-        if (fromState.balance < amount.add(fee)) {
+        if (amount == 0) return Types.Result.InvalidTokenAmount;
+
+        if (fromState.balance < amount.add(fee))
             return Types.Result.NotEnoughTokenBalance;
-        }
+
         return Types.Result.Ok;
     }
 }

--- a/contracts/libs/Transition.sol
+++ b/contracts/libs/Transition.sol
@@ -9,6 +9,28 @@ library Transition {
     using SafeMath for uint256;
     using Types for Types.UserState;
 
+    function processReceiver(
+        bytes32 stateRoot,
+        uint256 receiverStateIndex,
+        uint256 amount,
+        uint256 tokenType,
+        Types.StateMerkleProof memory proof
+    ) public pure returns (bytes32 newRoot, bytes memory newToState, Types.Result) {
+        Types.Result result = validateReceiver(
+            stateRoot,
+            receiverStateIndex,
+            tokenType,
+            proof
+        );
+        if (result != Types.Result.Ok) return (bytes32(0), "", result);
+        (newToState, newRoot) = ApplyReceiver(
+            proof,
+            receiverStateIndex,
+            amount
+        );
+        return (newRoot, newToState, Types.Result.Ok);
+    }
+
     function validateSender(
         bytes32 stateRoot,
         uint256 senderIndex,

--- a/contracts/libs/Transition.sol
+++ b/contracts/libs/Transition.sol
@@ -4,7 +4,7 @@ pragma experimental ABIEncoderV2;
 import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";
 import { Types } from "./Types.sol";
 
-library FraudProofHelpers {
+library Transition {
     using SafeMath for uint256;
 
     function validateTxBasic(

--- a/contracts/libs/Transition.sol
+++ b/contracts/libs/Transition.sol
@@ -3,20 +3,85 @@ pragma experimental ABIEncoderV2;
 
 import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";
 import { Types } from "./Types.sol";
+import { MerkleTreeUtilsLib } from "../MerkleTreeUtils.sol";
 
 library Transition {
     using SafeMath for uint256;
+    using Types for Types.UserState;
 
-    function validateTxBasic(
+    function validateSender(
+        bytes32 stateRoot,
+        uint256 senderIndex,
+        uint256 tokenType,
         uint256 amount,
         uint256 fee,
-        Types.UserState memory fromState
+        Types.StateMerkleProof memory sender
     ) internal pure returns (Types.Result) {
+        require(
+            MerkleTreeUtilsLib.verifyLeaf(
+                stateRoot,
+                keccak256(sender.state.encode()),
+                senderIndex,
+                sender.witness
+            ),
+            "Transfer: sender does not exist"
+        );
         if (amount == 0) return Types.Result.InvalidTokenAmount;
-
-        if (fromState.balance < amount.add(fee))
+        if (sender.state.balance < amount.add(fee))
             return Types.Result.NotEnoughTokenBalance;
-
+        if (sender.state.tokenType != tokenType)
+            return Types.Result.BadFromTokenType;
         return Types.Result.Ok;
+    }
+
+    function validateReceiver(
+        bytes32 stateRoot,
+        uint256 receiverIndex,
+        uint256 tokenType,
+        Types.StateMerkleProof memory receiver
+    ) internal pure returns (Types.Result) {
+        require(
+            MerkleTreeUtilsLib.verifyLeaf(
+                stateRoot,
+                keccak256(receiver.state.encode()),
+                receiverIndex,
+                receiver.witness
+            ),
+            "Transfer: receiver does not exist"
+        );
+        if (receiver.state.tokenType != tokenType)
+            return Types.Result.BadToTokenType;
+        return Types.Result.Ok;
+    }
+
+    function ApplySender(
+        Types.StateMerkleProof memory proof,
+        uint256 senderStateIndex,
+        uint256 decrement
+    ) public pure returns (bytes memory newState, bytes32 stateRoot) {
+        Types.UserState memory state = proof.state;
+        state.balance = state.balance.sub(decrement);
+        state.nonce++;
+        newState = state.encode();
+        stateRoot = MerkleTreeUtilsLib.rootFromWitnesses(
+            keccak256(newState),
+            senderStateIndex,
+            proof.witness
+        );
+    }
+
+    function ApplyReceiver(
+        Types.StateMerkleProof memory proof,
+        uint256 receiverStateIndex,
+        uint256 increment
+    ) public pure returns (bytes memory newState, bytes32 stateRoot) {
+        Types.UserState memory state = proof.state;
+        state.balance = state.balance.add(increment);
+        newState = state.encode();
+        stateRoot = MerkleTreeUtilsLib.rootFromWitnesses(
+            keccak256(newState),
+            receiverStateIndex,
+            proof.witness
+        );
     }
 }

--- a/contracts/libs/Transition.sol
+++ b/contracts/libs/Transition.sol
@@ -87,8 +87,9 @@ library Transition {
                 senderIndex,
                 sender.witness
             ),
-            "Transfer: sender does not exist"
+            "Transition: Sender does not exist"
         );
+        // We can only trust and validate the state after the merkle check
         if (amount == 0) return Types.Result.InvalidTokenAmount;
         if (sender.state.balance < amount.add(fee))
             return Types.Result.NotEnoughTokenBalance;
@@ -110,8 +111,9 @@ library Transition {
                 receiverIndex,
                 receiver.witness
             ),
-            "Transfer: receiver does not exist"
+            "Transition: receiver does not exist"
         );
+        // We can only trust and validate the state after the merkle check
         if (receiver.state.tokenType != tokenType)
             return Types.Result.BadToTokenType;
         return Types.Result.Ok;

--- a/contracts/libs/Transition.sol
+++ b/contracts/libs/Transition.sol
@@ -9,13 +9,54 @@ library Transition {
     using SafeMath for uint256;
     using Types for Types.UserState;
 
+    function processSender(
+        bytes32 stateRoot,
+        uint256 senderStateIndex,
+        uint256 tokenType,
+        uint256 amount,
+        uint256 fee,
+        Types.StateMerkleProof memory proof
+    )
+        internal
+        pure
+        returns (
+            bytes32 newRoot,
+            bytes memory newToState,
+            Types.Result
+        )
+    {
+        Types.Result result = validateSender(
+            stateRoot,
+            senderStateIndex,
+            tokenType,
+            amount,
+            fee,
+            proof
+        );
+        if (result != Types.Result.Ok) return (bytes32(0), "", result);
+        (newToState, newRoot) = ApplySender(
+            proof,
+            senderStateIndex,
+            amount.add(fee)
+        );
+        return (newRoot, newToState, Types.Result.Ok);
+    }
+
     function processReceiver(
         bytes32 stateRoot,
         uint256 receiverStateIndex,
         uint256 amount,
         uint256 tokenType,
         Types.StateMerkleProof memory proof
-    ) public pure returns (bytes32 newRoot, bytes memory newToState, Types.Result) {
+    )
+        internal
+        pure
+        returns (
+            bytes32 newRoot,
+            bytes memory newToState,
+            Types.Result
+        )
+    {
         Types.Result result = validateReceiver(
             stateRoot,
             receiverStateIndex,


### PR DESCRIPTION
We now have every state transition fits the following style

```
 processSender
  validateSender
  applySender
processReceiver
  validateReceiver
  applyReceiver
```
And we can remove all processFees, because they are just another processReceiver.
