### PR TITLE
alternative transition design

### DIFF
--- a/contracts/Create2Transfer.sol
+++ b/contracts/Create2Transfer.sol
@@ -152,7 +152,7 @@ contract Create2Transfer {
     function processCreate2TransferReceiver(
         bytes32 stateRoot,
         Tx.Create2Transfer memory _tx,
-        uint256 token,
+        uint256 tokenType,
         Types.StateMerkleProof memory proof
     ) internal pure returns (bytes memory encodedState, bytes32 newRoot) {
         // Validate we are creating on a zero state
@@ -165,13 +165,12 @@ contract Create2Transfer {
             ),
             "Create2Transfer: receiver proof invalid"
         );
-        Types.UserState memory newState = Types.UserState(
+        encodedState = Transition.createState(
             _tx.toAccID,
-            token,
-            _tx.amount,
-            0
+            tokenType,
+            _tx.amount
         );
-        encodedState = newState.encode();
+
         newRoot = MerkleTree.computeRoot(
             keccak256(encodedState),
             _tx.toIndex,

--- a/contracts/Create2Transfer.sol
+++ b/contracts/Create2Transfer.sol
@@ -109,8 +109,8 @@ contract Create2Transfer {
         (stateRoot, result) = Transition.processReceiver(
             stateRoot,
             feeReceiver,
-            fees,
             tokenType,
+            fees,
             proofs[length * 2]
         );
 

--- a/contracts/Create2Transfer.sol
+++ b/contracts/Create2Transfer.sol
@@ -106,7 +106,7 @@ contract Create2Transfer {
             // Only trust fees when the result is good
             fees = fees.add(_tx.fee);
         }
-        (stateRoot, , result) = Transition.processReceiver(
+        (stateRoot, result) = Transition.processReceiver(
             stateRoot,
             feeReceiver,
             fees,
@@ -130,7 +130,7 @@ contract Create2Transfer {
         Types.StateMerkleProof memory from,
         Types.StateMerkleProof memory to
     ) internal pure returns (bytes32 newRoot, Types.Result result) {
-        (newRoot, , result) = Transition.processSender(
+        (newRoot, result) = Transition.processSender(
             stateRoot,
             _tx.fromIndex,
             tokenType,

--- a/contracts/MassMigrations.sol
+++ b/contracts/MassMigrations.sol
@@ -101,8 +101,8 @@ contract MassMigration {
         (stateRoot, result) = Transition.processReceiver(
             stateRoot,
             commitmentBody.feeReceiver,
-            fees,
             commitmentBody.tokenID,
+            fees,
             proofs[length]
         );
         if (result != Types.Result.Ok) return (stateRoot, result);

--- a/contracts/MassMigrations.sol
+++ b/contracts/MassMigrations.sol
@@ -98,7 +98,7 @@ contract MassMigration {
             fees += _tx.fee;
             withdrawLeaves[i] = keccak256(freshState);
         }
-        (stateRoot, , result) = Transition.processReceiver(
+        (stateRoot, result) = Transition.processReceiver(
             stateRoot,
             commitmentBody.feeReceiver,
             fees,
@@ -130,7 +130,7 @@ contract MassMigration {
             Types.Result result
         )
     {
-        (newRoot, , result) = Transition.processSender(
+        (newRoot, result) = Transition.processSender(
             stateRoot,
             _tx.fromIndex,
             tokenType,

--- a/contracts/MassMigrations.sol
+++ b/contracts/MassMigrations.sol
@@ -139,14 +139,11 @@ contract MassMigration {
             from
         );
         if (result != Types.Result.Ok) return (newRoot, "", result);
-
-        Types.UserState memory fresh = Types.UserState({
-            pubkeyIndex: from.state.pubkeyIndex,
-            tokenType: tokenType,
-            balance: _tx.amount,
-            nonce: 0
-        });
-        freshState = fresh.encode();
+        freshState = Transition.createState(
+            from.state.pubkeyIndex,
+            tokenType,
+            _tx.amount
+        );
 
         return (newRoot, freshState, Types.Result.Ok);
     }

--- a/contracts/Transfer.sol
+++ b/contracts/Transfer.sol
@@ -94,8 +94,8 @@ contract Transfer {
         (stateRoot, result) = Transition.processReceiver(
             stateRoot,
             feeReceiver,
-            fees,
             tokenType,
+            fees,
             proofs[length * 2]
         );
 
@@ -127,8 +127,8 @@ contract Transfer {
         (newRoot, result) = Transition.processReceiver(
             newRoot,
             _tx.toIndex,
-            _tx.amount,
             tokenType,
+            _tx.amount,
             to
         );
         return (newRoot, result);

--- a/contracts/Transfer.sol
+++ b/contracts/Transfer.sol
@@ -91,7 +91,7 @@ contract Transfer {
             // Only trust fees when the result is good
             fees = fees.add(_tx.fee);
         }
-        (stateRoot, , result) = Transition.processReceiver(
+        (stateRoot, result) = Transition.processReceiver(
             stateRoot,
             feeReceiver,
             fees,
@@ -115,7 +115,7 @@ contract Transfer {
         Types.StateMerkleProof memory from,
         Types.StateMerkleProof memory to
     ) internal pure returns (bytes32 newRoot, Types.Result result) {
-        (newRoot, , result) = Transition.processSender(
+        (newRoot, result) = Transition.processSender(
             stateRoot,
             _tx.fromIndex,
             tokenType,
@@ -124,7 +124,7 @@ contract Transfer {
             from
         );
         if (result != Types.Result.Ok) return (newRoot, result);
-        (newRoot, , result) = Transition.processReceiver(
+        (newRoot, result) = Transition.processReceiver(
             newRoot,
             _tx.toIndex,
             _tx.amount,

--- a/contracts/libs/Transition.sol
+++ b/contracts/libs/Transition.sol
@@ -103,4 +103,18 @@ library Transition {
         });
         return (newReceiver, Types.Result.Ok);
     }
+
+    function createState(
+        uint256 pubkeyIndex,
+        uint256 tokenType,
+        uint256 amount
+    ) internal pure returns (bytes memory stateEncoded) {
+        Types.UserState memory state = Types.UserState({
+            pubkeyIndex: pubkeyIndex,
+            tokenType: tokenType,
+            balance: amount,
+            nonce: 0
+        });
+        return state.encode();
+    }
 }

--- a/contracts/libs/Transition.sol
+++ b/contracts/libs/Transition.sol
@@ -16,30 +16,27 @@ library Transition {
         uint256 amount,
         uint256 fee,
         Types.StateMerkleProof memory proof
-    )
-        internal
-        pure
-        returns (
-            bytes32 newRoot,
-            bytes memory newToState,
-            Types.Result
-        )
-    {
-        Types.Result result = validateSender(
-            stateRoot,
-            senderStateIndex,
-            tokenType,
-            amount,
-            fee,
-            proof
+    ) internal pure returns (bytes32 newRoot, Types.Result) {
+        require(
+            MerkleTree.verify(
+                stateRoot,
+                keccak256(proof.state.encode()),
+                senderStateIndex,
+                proof.witness
+            ),
+            "Transition: Sender does not exist"
         );
-        if (result != Types.Result.Ok) return (bytes32(0), "", result);
-        (newToState, newRoot) = applySender(
-            proof,
+        (
+            Types.UserState memory newSender,
+            Types.Result result
+        ) = validateAndApplySender(tokenType, amount, fee, proof.state);
+        if (result != Types.Result.Ok) return (bytes32(0), result);
+        newRoot = MerkleTree.computeRoot(
+            keccak256(newSender.encode()),
             senderStateIndex,
-            amount.add(fee)
+            proof.witness
         );
-        return (newRoot, newToState, Types.Result.Ok);
+        return (newRoot, Types.Result.Ok);
     }
 
     function processReceiver(
@@ -48,105 +45,62 @@ library Transition {
         uint256 amount,
         uint256 tokenType,
         Types.StateMerkleProof memory proof
-    )
-        internal
-        pure
-        returns (
-            bytes32 newRoot,
-            bytes memory newToState,
-            Types.Result
-        )
-    {
-        Types.Result result = validateReceiver(
-            stateRoot,
-            receiverStateIndex,
-            tokenType,
-            proof
-        );
-        if (result != Types.Result.Ok) return (bytes32(0), "", result);
-        (newToState, newRoot) = applyReceiver(
-            proof,
-            receiverStateIndex,
-            amount
-        );
-        return (newRoot, newToState, Types.Result.Ok);
-    }
-
-    function validateSender(
-        bytes32 stateRoot,
-        uint256 senderIndex,
-        uint256 tokenType,
-        uint256 amount,
-        uint256 fee,
-        Types.StateMerkleProof memory sender
-    ) internal pure returns (Types.Result) {
+    ) internal pure returns (bytes32 newRoot, Types.Result) {
         require(
             MerkleTree.verify(
                 stateRoot,
-                keccak256(sender.state.encode()),
-                senderIndex,
-                sender.witness
-            ),
-            "Transition: Sender does not exist"
-        );
-        // We can only trust and validate the state after the merkle check
-        if (amount == 0) return Types.Result.InvalidTokenAmount;
-        if (sender.state.balance < amount.add(fee))
-            return Types.Result.NotEnoughTokenBalance;
-        if (sender.state.tokenType != tokenType)
-            return Types.Result.BadFromTokenType;
-        return Types.Result.Ok;
-    }
-
-    function validateReceiver(
-        bytes32 stateRoot,
-        uint256 receiverIndex,
-        uint256 tokenType,
-        Types.StateMerkleProof memory receiver
-    ) internal pure returns (Types.Result) {
-        require(
-            MerkleTree.verify(
-                stateRoot,
-                keccak256(receiver.state.encode()),
-                receiverIndex,
-                receiver.witness
+                keccak256(proof.state.encode()),
+                receiverStateIndex,
+                proof.witness
             ),
             "Transition: receiver does not exist"
         );
-        // We can only trust and validate the state after the merkle check
-        if (receiver.state.tokenType != tokenType)
-            return Types.Result.BadToTokenType;
-        return Types.Result.Ok;
-    }
-
-    function applySender(
-        Types.StateMerkleProof memory proof,
-        uint256 senderStateIndex,
-        uint256 decrement
-    ) internal pure returns (bytes memory newState, bytes32 stateRoot) {
-        Types.UserState memory state = proof.state;
-        state.balance = state.balance.sub(decrement);
-        state.nonce++;
-        newState = state.encode();
+        (
+            Types.UserState memory newReceiver,
+            Types.Result result
+        ) = validateAndApplyReceiver(tokenType, amount, proof.state);
+        if (result != Types.Result.Ok) return (bytes32(0), result);
         stateRoot = MerkleTree.computeRoot(
-            keccak256(newState),
-            senderStateIndex,
-            proof.witness
-        );
-    }
-
-    function applyReceiver(
-        Types.StateMerkleProof memory proof,
-        uint256 receiverStateIndex,
-        uint256 increment
-    ) internal pure returns (bytes memory newState, bytes32 stateRoot) {
-        Types.UserState memory state = proof.state;
-        state.balance = state.balance.add(increment);
-        newState = state.encode();
-        stateRoot = MerkleTree.computeRoot(
-            keccak256(newState),
+            keccak256(newReceiver.encode()),
             receiverStateIndex,
             proof.witness
         );
+        return (newRoot, Types.Result.Ok);
+    }
+
+    function validateAndApplySender(
+        uint256 tokenType,
+        uint256 amount,
+        uint256 fee,
+        Types.UserState memory sender
+    ) internal pure returns (Types.UserState memory, Types.Result) {
+        if (amount == 0) return (sender, Types.Result.InvalidTokenAmount);
+        if (sender.balance < amount.add(fee))
+            return (sender, Types.Result.NotEnoughTokenBalance);
+        if (sender.tokenType != tokenType)
+            return (sender, Types.Result.BadFromTokenType);
+        Types.UserState memory newSender = Types.UserState({
+            pubkeyIndex: sender.pubkeyIndex,
+            tokenType: sender.tokenType,
+            balance: sender.balance.sub(amount.add(fee)),
+            nonce: sender.nonce.add(1)
+        });
+        return (newSender, Types.Result.Ok);
+    }
+
+    function validateAndApplyReceiver(
+        uint256 tokenType,
+        uint256 amount,
+        Types.UserState memory receiver
+    ) internal pure returns (Types.UserState memory newReceiver, Types.Result) {
+        if (receiver.tokenType != tokenType)
+            return (receiver, Types.Result.BadToTokenType);
+        newReceiver = Types.UserState({
+            pubkeyIndex: receiver.pubkeyIndex,
+            tokenType: receiver.tokenType,
+            balance: receiver.balance.add(amount),
+            nonce: receiver.nonce.add(1)
+        });
+        return (newReceiver, Types.Result.Ok);
     }
 }

--- a/contracts/libs/Transition.sol
+++ b/contracts/libs/Transition.sol
@@ -60,7 +60,7 @@ library Transition {
             Types.Result result
         ) = validateAndApplyReceiver(tokenType, amount, proof.state);
         if (result != Types.Result.Ok) return (bytes32(0), result);
-        stateRoot = MerkleTree.computeRoot(
+        newRoot = MerkleTree.computeRoot(
             keccak256(newReceiver.encode()),
             receiverStateIndex,
             proof.witness
@@ -75,14 +75,15 @@ library Transition {
         Types.UserState memory sender
     ) internal pure returns (Types.UserState memory, Types.Result) {
         if (amount == 0) return (sender, Types.Result.InvalidTokenAmount);
-        if (sender.balance < amount.add(fee))
+        uint256 decrement = amount.add(fee);
+        if (sender.balance < decrement)
             return (sender, Types.Result.NotEnoughTokenBalance);
         if (sender.tokenType != tokenType)
             return (sender, Types.Result.BadFromTokenType);
         Types.UserState memory newSender = Types.UserState({
             pubkeyIndex: sender.pubkeyIndex,
             tokenType: sender.tokenType,
-            balance: sender.balance.sub(amount.add(fee)),
+            balance: sender.balance.sub(decrement),
             nonce: sender.nonce.add(1)
         });
         return (newSender, Types.Result.Ok);
@@ -99,7 +100,7 @@ library Transition {
             pubkeyIndex: receiver.pubkeyIndex,
             tokenType: receiver.tokenType,
             balance: receiver.balance.add(amount),
-            nonce: receiver.nonce.add(1)
+            nonce: receiver.nonce
         });
         return (newReceiver, Types.Result.Ok);
     }

--- a/contracts/libs/Transition.sol
+++ b/contracts/libs/Transition.sol
@@ -42,8 +42,8 @@ library Transition {
     function processReceiver(
         bytes32 stateRoot,
         uint256 receiverStateIndex,
-        uint256 amount,
         uint256 tokenType,
+        uint256 amount,
         Types.StateMerkleProof memory proof
     ) internal pure returns (bytes32 newRoot, Types.Result) {
         require(

--- a/contracts/libs/Types.sol
+++ b/contracts/libs/Types.sol
@@ -221,6 +221,15 @@ library Types {
             );
     }
 
+    function decodeState(bytes memory encoded)
+        internal
+        pure
+        returns (Types.UserState memory state)
+    {
+        (state.pubkeyIndex, state.tokenType, state.balance, state.nonce) = abi
+            .decode(encoded, (uint256, uint256, uint256, uint256));
+    }
+
     struct StateMerkleProof {
         UserState state;
         bytes32[] witness;


### PR DESCRIPTION
- Highlight the Merkle checks and compute roots in `processX` API.
- Merge `validateX` and `applyX` APIs, because those are what the coordinator and the client care.
- The client consumes `validateAndApply` API.
  - No Merkle computation in those functions.
  - states input/output are in encoded form. The client can be state agnostic.