### PR TITLE
Submit commitment check

### DIFF
--- a/contracts/Governance.sol
+++ b/contracts/Governance.sol
@@ -27,10 +27,10 @@ contract Governance {
         return govMinGasLeft;
     }
 
-    uint256 public govMaxTxsPerBatch = 32;
+    uint256 public govMaxTxsPerCommit = 32;
 
-    function maxTxsPerBatch() public view returns (uint256) {
-        return govMaxTxsPerBatch;
+    function maxTxsPerCommit() public view returns (uint256) {
+        return govMaxTxsPerCommit;
     }
 
     uint256 public govStakeAmount = 0.1 ether;

--- a/contracts/Rollup.sol
+++ b/contracts/Rollup.sol
@@ -287,6 +287,10 @@ contract Rollup is RollupHelpers {
         bytes32 accountRoot = accountRegistry.root();
         bytes32 bodyRoot;
         for (uint256 i = 0; i < stateRoots.length; i++) {
+            require(
+                !txss[i].transferHasExcessData(),
+                "Rollup: transfer has excess data"
+            );
             // This is TransferBody toHash() but we don't want the overhead of struct
             bodyRoot = keccak256(
                 abi.encodePacked(
@@ -318,6 +322,10 @@ contract Rollup is RollupHelpers {
         bytes32 accountRoot = accountRegistry.root();
         bytes32 bodyRoot;
         for (uint256 i = 0; i < stateRoots.length; i++) {
+            require(
+                !txss[i].create2TransferHasExcessData(),
+                "Rollup: Create2Transfer has excess data"
+            );
             // This is TransferBody toHash() but we don't want the overhead of struct
             bodyRoot = keccak256(
                 abi.encodePacked(
@@ -350,6 +358,10 @@ contract Rollup is RollupHelpers {
         bytes32[] memory leaves = new bytes32[](stateRoots.length);
         bytes32 accountRoot = accountRegistry.root();
         for (uint256 i = 0; i < stateRoots.length; i++) {
+            require(
+                !txss[i].massMigrationHasExcessData(),
+                "Rollup: MassMigration has excess data"
+            );
             Types.MassMigrationBody memory body = Types.MassMigrationBody(
                 accountRoot,
                 signatures[i],

--- a/contracts/Rollup.sol
+++ b/contracts/Rollup.sol
@@ -290,14 +290,6 @@ contract Rollup is RollupHelpers {
         bytes32 accountRoot = accountRegistry.root();
         bytes32 bodyRoot;
         for (uint256 i = 0; i < stateRoots.length; i++) {
-            require(
-                !txss[i].transferHasExcessData(),
-                "Rollup: transfer has excess data"
-            );
-            require(
-                txss[i].transferSize() <= govMaxTxsPerCommit,
-                "Rollup: commit too many transfer"
-            );
             // This is TransferBody toHash() but we don't want the overhead of struct
             bodyRoot = keccak256(
                 abi.encodePacked(
@@ -329,14 +321,6 @@ contract Rollup is RollupHelpers {
         bytes32 accountRoot = accountRegistry.root();
         bytes32 bodyRoot;
         for (uint256 i = 0; i < stateRoots.length; i++) {
-            require(
-                !txss[i].create2TransferHasExcessData(),
-                "Rollup: Create2Transfer has excess data"
-            );
-            require(
-                txss[i].massMigrationSize() <= govMaxTxsPerCommit,
-                "Rollup: commit too many Create2Transfer"
-            );
             // This is TransferBody toHash() but we don't want the overhead of struct
             bodyRoot = keccak256(
                 abi.encodePacked(
@@ -369,14 +353,6 @@ contract Rollup is RollupHelpers {
         bytes32[] memory leaves = new bytes32[](stateRoots.length);
         bytes32 accountRoot = accountRegistry.root();
         for (uint256 i = 0; i < stateRoots.length; i++) {
-            require(
-                !txss[i].massMigrationHasExcessData(),
-                "Rollup: MassMigration has excess data"
-            );
-            require(
-                txss[i].massMigrationSize() <= govMaxTxsPerCommit,
-                "Rollup: commit too many MassMigration"
-            );
             Types.MassMigrationBody memory body = Types.MassMigrationBody(
                 accountRoot,
                 signatures[i],
@@ -464,9 +440,10 @@ contract Rollup is RollupHelpers {
         (bytes32 processedStateRoot, Types.Result result) = transfer
             .processTransferCommit(
             previous.commitment.stateRoot,
+            govMaxTxsPerCommit,
+            target.commitment.body.feeReceiver,
             target.commitment.body.txs,
-            proofs,
-            target.commitment.body.feeReceiver
+            proofs
         );
 
         if (
@@ -499,6 +476,7 @@ contract Rollup is RollupHelpers {
         (bytes32 processedStateRoot, Types.Result result) = massMigration
             .processMassMigrationCommit(
             previous.commitment.stateRoot,
+            govMaxTxsPerCommit,
             target.commitment.body,
             proofs
         );

--- a/contracts/libs/Tx.sol
+++ b/contracts/libs/Tx.sol
@@ -322,6 +322,14 @@ library Tx {
         return MassMigration(sender, amount, fee);
     }
 
+    function massMigrationHasExcessData(bytes memory txs)
+        internal
+        pure
+        returns (bool)
+    {
+        return txs.length % TX_LEN_5 != 0;
+    }
+
     function massMigrationSize(bytes memory txs)
         internal
         pure

--- a/contracts/libs/Types.sol
+++ b/contracts/libs/Types.sol
@@ -251,6 +251,8 @@ library Types {
         BadToTokenType,
         BadSignature,
         MismatchedAmount,
-        BadWithdrawRoot
+        BadWithdrawRoot,
+        BadCompression,
+        TooManyTx
     }
 }

--- a/contracts/test/TestCreate2Transfer.sol
+++ b/contracts/test/TestCreate2Transfer.sol
@@ -46,17 +46,19 @@ contract TestCreate2Transfer is Create2Transfer {
 
     function testProcessCreate2TransferCommit(
         bytes32 stateRoot,
+        uint256 maxTxSize,
+        uint256 feeReceiver,
         bytes memory txs,
-        Types.StateMerkleProof[] memory proofs,
-        uint256 feeReceiver
+        Types.StateMerkleProof[] memory proofs
     ) public returns (bytes32, uint256) {
         bytes32 newRoot;
         uint256 operationCost = gasleft();
         (newRoot, ) = processCreate2TransferCommit(
             stateRoot,
+            maxTxSize,
+            feeReceiver,
             txs,
-            proofs,
-            feeReceiver
+            proofs
         );
         return (newRoot, operationCost - gasleft());
     }

--- a/contracts/test/TestMassMigration.sol
+++ b/contracts/test/TestMassMigration.sol
@@ -29,6 +29,7 @@ contract TestMassMigration is MassMigration {
 
     function testProcessMassMigrationCommit(
         bytes32 stateRoot,
+        uint256 maxTxSize,
         Types.MassMigrationBody memory commitmentBody,
         Types.StateMerkleProof[] memory proofs
     )
@@ -43,6 +44,7 @@ contract TestMassMigration is MassMigration {
         gasCost = gasleft();
         (bytes32 postRoot, Types.Result result) = processMassMigrationCommit(
             stateRoot,
+            maxTxSize,
             commitmentBody,
             proofs
         );

--- a/contracts/test/TestTransfer.sol
+++ b/contracts/test/TestTransfer.sol
@@ -40,17 +40,19 @@ contract TestTransfer is Transfer {
 
     function testProcessTransferCommit(
         bytes32 stateRoot,
+        uint256 maxTxSize,
+        uint256 feeReceiver,
         bytes memory txs,
-        Types.StateMerkleProof[] memory proofs,
-        uint256 feeReceiver
+        Types.StateMerkleProof[] memory proofs
     ) public returns (bytes32, uint256) {
         bytes32 newRoot;
         uint256 operationCost = gasleft();
         (newRoot, ) = processTransferCommit(
             stateRoot,
+            maxTxSize,
+            feeReceiver,
             txs,
-            proofs,
-            feeReceiver
+            proofs
         );
         return (newRoot, operationCost - gasleft());
     }

--- a/test/MassMigration.test.ts
+++ b/test/MassMigration.test.ts
@@ -1,5 +1,5 @@
 import { deployAll } from "../ts/deploy";
-import { TESTING_PARAMS } from "../ts/constants";
+import { COMMIT_SIZE, TESTING_PARAMS } from "../ts/constants";
 import { ethers } from "@nomiclabs/buidler";
 import { StateTree } from "../ts/stateTree";
 import { AccountRegistry } from "../ts/accountTree";
@@ -97,6 +97,7 @@ describe("Mass Migrations", async function() {
             1: result
         } = await massMigration.processMassMigrationCommit(
             stateRoot,
+            COMMIT_SIZE,
             commitment.toSolStruct().body,
             proofs
         );

--- a/test/rollupMassMigration.test.ts
+++ b/test/rollupMassMigration.test.ts
@@ -137,6 +137,7 @@ describe("Rollup Mass Migration", () => {
             2: result
         } = await rollup.callStatic.testProcessMassMigrationCommit(
             preStateRoot,
+            COMMIT_SIZE,
             commitmentBody,
             proofs
         );

--- a/test/rollupTransfer.test.ts
+++ b/test/rollupTransfer.test.ts
@@ -159,9 +159,10 @@ describe("Rollup Transfer Commitment", () => {
             1: gasCost
         } = await rollup.callStatic.testProcessTransferCommit(
             preStateRoot,
+            COMMIT_SIZE,
+            feeReceiver,
             serialize(txs),
-            proofs,
-            feeReceiver
+            proofs
         );
         console.log("processTransferBatch gas cost", gasCost.toNumber());
         assert.equal(postRoot, postStateRoot, "Mismatch post state root");

--- a/ts/interfaces.ts
+++ b/ts/interfaces.ts
@@ -20,5 +20,7 @@ export enum Result {
     BadToTokenType,
     BadSignature,
     MismatchedAmount,
-    BadWithdrawRoot
+    BadWithdrawRoot,
+    BadCompression,
+    TooManyTx
 }


### PR DESCRIPTION
1. check if compressed txs are decompressible
2. check if they exceed govMaxTxsPerCommit

Note: Doing these checks in submitBatch might hurt tps. Also, we use 2 function calls, could combine them into 1. I'm thinking of doing this for the time being and optimize later