### PR TITLE
Pubkeys on invalid subgroup checks

### DIFF
--- a/contracts/BLSAccountRegistry.sol
+++ b/contracts/BLSAccountRegistry.sol
@@ -12,10 +12,6 @@ contract BLSAccountRegistry is AccountTree {
     }
 
     function register(uint256[4] calldata pubkey) external returns (uint256) {
-        require(
-            BLS.isValidPublicKey(pubkey),
-            "BLSAccountTree: invalid pub key"
-        );
         bytes32 leaf = keccak256(abi.encodePacked(pubkey));
         uint256 accountID = _updateSingle(leaf);
         logger.logPubkeyRegistered(pubkey, accountID);
@@ -28,10 +24,6 @@ contract BLSAccountRegistry is AccountTree {
     {
         bytes32[BATCH_SIZE] memory leafs;
         for (uint256 i = 0; i < BATCH_SIZE; i++) {
-            require(
-                BLS.isValidPublicKey(pubkeys[i]),
-                "BLSAccountTree: invalid pub key"
-            );
             logger.logPubkeyRegistered(
                 pubkeys[i],
                 leafIndexRight + SET_SIZE + i

--- a/contracts/WithdrawManager.sol
+++ b/contracts/WithdrawManager.sol
@@ -99,14 +99,16 @@ contract WithdrawManager {
             ),
             "WithdrawManager: Public key should be in the Registry"
         );
-        require(
-            BLS.verifySingle(
-                signature,
-                pubkey,
-                BLS.hashToPoint(appID, abi.encodePacked(msg.sender))
-            ),
-            "WithdrawManager: Bad signature"
+
+        bool callSuccess;
+        bool checkSuccess;
+        (checkSuccess, callSuccess) = BLS.verifySingle(
+            signature,
+            pubkey,
+            BLS.hashToPoint(appID, abi.encodePacked(msg.sender))
         );
+        require(callSuccess, "WithdrawManager: Precompile call failed");
+        require(checkSuccess, "WithdrawManager: Bad signature");
 
         IERC20 tokenContract = IERC20(
             tokenRegistry.safeGetAddress(withdrawal.state.tokenType)

--- a/contracts/client/ClientFrontend.sol
+++ b/contracts/client/ClientFrontend.sol
@@ -79,8 +79,16 @@ contract ClientFrontend {
             _tx.fee
         );
         bytes memory txMsg = Tx.transferMessageOf(txTx, _tx.nonce);
-        uint256[2] memory message = BLS.hashToPoint(domain, txMsg);
-        require(BLS.verifySingle(signature, pubkey, message), "Bad Signature");
+
+        bool callSuccess;
+        bool checkSuccess;
+        (checkSuccess, callSuccess) = BLS.verifySingle(
+            signature,
+            pubkey,
+            BLS.hashToPoint(domain, txMsg)
+        );
+        require(callSuccess, "Precompile call failed");
+        require(checkSuccess, "Bad signature");
     }
 
     function validateAndApplyTransfer(

--- a/contracts/libs/Authenticity.sol
+++ b/contracts/libs/Authenticity.sol
@@ -52,7 +52,17 @@ library Authenticity {
             );
             messages[i] = BLS.hashToPoint(domain, txMsg);
         }
-        if (!BLS.verifyMultiple(signature, proof.pubkeys, messages)) {
+        bool callSuccess;
+        bool checkSuccess;
+        (checkSuccess, callSuccess) = BLS.verifyMultiple(
+            signature,
+            proof.pubkeys,
+            messages
+        );
+        if (!callSuccess) {
+            return Types.Result.BadPrecompileCall;
+        }
+        if (!checkSuccess) {
             return Types.Result.BadSignature;
         }
         return Types.Result.Ok;
@@ -102,9 +112,20 @@ library Authenticity {
             );
             messages[i] = BLS.hashToPoint(domain, txMsg);
         }
-        if (!BLS.verifyMultiple(signature, proof.pubkeys, messages)) {
+        bool callSuccess;
+        bool checkSuccess;
+        (checkSuccess, callSuccess) = BLS.verifyMultiple(
+            signature,
+            proof.pubkeys,
+            messages
+        );
+        if (!callSuccess) {
+            return Types.Result.BadPrecompileCall;
+        }
+        if (!checkSuccess) {
             return Types.Result.BadSignature;
         }
+
         return Types.Result.Ok;
     }
 
@@ -166,8 +187,17 @@ library Authenticity {
 
             messages[i] = BLS.hashToPoint(domain, txMsg);
         }
-
-        if (!BLS.verifyMultiple(signature, proof.pubkeysSender, messages)) {
+        bool callSuccess;
+        bool checkSuccess;
+        (checkSuccess, callSuccess) = BLS.verifyMultiple(
+            signature,
+            proof.pubkeysSender,
+            messages
+        );
+        if (!callSuccess) {
+            return Types.Result.BadPrecompileCall;
+        }
+        if (!checkSuccess) {
             return Types.Result.BadSignature;
         }
         return Types.Result.Ok;

--- a/contracts/libs/BLS.sol
+++ b/contracts/libs/BLS.sol
@@ -216,22 +216,6 @@ library BLS {
         return [x, a1];
     }
 
-    function isValidPublicKey(uint256[4] memory publicKey)
-        internal
-        pure
-        returns (bool)
-    {
-        if (
-            (publicKey[0] >= N) ||
-            (publicKey[1] >= N) ||
-            (publicKey[2] >= N || (publicKey[3] >= N))
-        ) {
-            return false;
-        } else {
-            return isOnCurveG2(publicKey);
-        }
-    }
-
     function isValidSignature(uint256[2] memory signature)
         internal
         pure

--- a/contracts/libs/Types.sol
+++ b/contracts/libs/Types.sol
@@ -244,6 +244,7 @@ library Types {
         MismatchedAmount,
         BadWithdrawRoot,
         BadCompression,
-        TooManyTx
+        TooManyTx,
+        BadPrecompileCall
     }
 }

--- a/contracts/test/TestBLS.sol
+++ b/contracts/test/TestBLS.sol
@@ -7,7 +7,7 @@ contract TestBLS {
         uint256[2] calldata signature,
         uint256[4][] calldata pubkeys,
         uint256[2][] calldata messages
-    ) external view returns (bool) {
+    ) external view returns (bool, bool) {
         return BLS.verifyMultiple(signature, pubkeys, messages);
     }
 
@@ -15,7 +15,7 @@ contract TestBLS {
         uint256[2] calldata signature,
         uint256[4] calldata pubkey,
         uint256[2] calldata message
-    ) external view returns (bool) {
+    ) external view returns (bool, bool) {
         return BLS.verifySingle(signature, pubkey, message);
     }
 
@@ -69,10 +69,15 @@ contract TestBLS {
         uint256[2][] calldata messages
     ) external returns (uint256) {
         uint256 g = gasleft();
-        require(
-            BLS.verifyMultiple(signature, pubkeys, messages),
-            "BLSTest: expect succesful verification"
+        bool callSuccess;
+        bool checkSuccess;
+        (checkSuccess, callSuccess) = BLS.verifyMultiple(
+            signature,
+            pubkeys,
+            messages
         );
+        require(callSuccess, "BLSTest: expect succesful precompile call");
+        require(checkSuccess, "BLSTest: expect succesful verification");
         return g - gasleft();
     }
 
@@ -82,10 +87,16 @@ contract TestBLS {
         uint256[2] calldata message
     ) external returns (uint256) {
         uint256 g = gasleft();
-        require(
-            BLS.verifySingle(signature, pubkey, message),
-            "BLSTest: expect succesful verification"
+
+        bool callSuccess;
+        bool checkSuccess;
+        (checkSuccess, callSuccess) = BLS.verifySingle(
+            signature,
+            pubkey,
+            message
         );
+        require(callSuccess, "BLSTest: expect succesful call");
+        require(checkSuccess, "BLSTest: expect succesful verification");
         return g - gasleft();
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4609,7 +4609,6 @@
           "resolved": "https://registry.npmjs.org/@types/bignumber.js/-/bignumber.js-5.0.0.tgz",
           "integrity": "sha512-0DH7aPGCClywOFaxxjE6UwpN2kQYe9LwuDQMv+zYA97j5GkOMo8e66LYT+a8JYU7jfmUFRZLa9KycxHDsKXJCA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "bignumber.js": "*"
           }
@@ -4679,7 +4678,6 @@
           "resolved": "https://registry.npmjs.org/@web3-js/websocket/-/websocket-1.0.30.tgz",
           "integrity": "sha512-fDwrD47MiDrzcJdSeTLF75aCcxVVt8B1N74rA+vh2XCAvFy4tEWJjtnUtj2QG7/zlQ6g9cQ88bZFBxwd9/FmtA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "debug": "^2.2.0",
             "es5-ext": "^0.10.50",
@@ -4693,7 +4691,6 @@
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -4702,8 +4699,7 @@
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
               "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -4786,8 +4782,7 @@
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
           "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "anymatch": {
           "version": "2.0.0",
@@ -4954,7 +4949,6 @@
           "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
           "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "bn.js": "^4.0.0",
             "inherits": "^2.0.1",
@@ -5882,8 +5876,7 @@
           "version": "9.0.0",
           "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
           "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "binary-extensions": {
           "version": "1.13.1",
@@ -5927,7 +5920,6 @@
           "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
           "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "readable-stream": "^2.3.5",
             "safe-buffer": "^5.1.1"
@@ -5937,15 +5929,13 @@
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "readable-stream": {
               "version": "2.3.7",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
               "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -5960,8 +5950,7 @@
                   "version": "5.1.2",
                   "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
                   "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-                  "dev": true,
-                  "optional": true
+                  "dev": true
                 }
               }
             },
@@ -5970,7 +5959,6 @@
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
               },
@@ -5979,8 +5967,7 @@
                   "version": "5.1.2",
                   "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
                   "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-                  "dev": true,
-                  "optional": true
+                  "dev": true
                 }
               }
             }
@@ -6010,7 +5997,6 @@
           "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
           "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "bytes": "3.1.0",
             "content-type": "~1.0.4",
@@ -6029,7 +6015,6 @@
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -6038,8 +6023,7 @@
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
               "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -6132,7 +6116,6 @@
           "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
           "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
           "dev": true,
-          "optional": true,
           "requires": {
             "bn.js": "^4.1.0",
             "randombytes": "^2.0.1"
@@ -6210,7 +6193,6 @@
           "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
           "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
           "dev": true,
-          "optional": true,
           "requires": {
             "buffer-alloc-unsafe": "^1.1.0",
             "buffer-fill": "^1.0.0"
@@ -6220,8 +6202,7 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
           "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "buffer-crc32": {
           "version": "0.2.13",
@@ -6240,8 +6221,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
           "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "buffer-from": {
           "version": "1.1.1",
@@ -6253,8 +6233,7 @@
           "version": "0.0.5",
           "resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
           "integrity": "sha1-YGSkD6dutDxyOrqe+PbhIW0QURo=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "buffer-xor": {
           "version": "1.0.3",
@@ -6266,8 +6245,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
           "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "bytewise": {
           "version": "1.1.0",
@@ -6692,8 +6670,7 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
           "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "convert-source-map": {
           "version": "1.7.0",
@@ -6730,8 +6707,7 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
           "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "copy-descriptor": {
           "version": "0.1.1",
@@ -6917,7 +6893,6 @@
           "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
           "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "mimic-response": "^1.0.0"
           }
@@ -6927,7 +6902,6 @@
           "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
           "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "file-type": "^5.2.0",
             "is-stream": "^1.1.0",
@@ -7155,8 +7129,7 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
           "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "des.js": {
           "version": "1.0.1",
@@ -7173,8 +7146,7 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
           "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "detect-file": {
           "version": "1.0.0",
@@ -7233,8 +7205,7 @@
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
           "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "duplexify": {
           "version": "3.7.1",
@@ -7310,8 +7281,7 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
           "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "electron-to-chromium": {
           "version": "1.3.521",
@@ -7338,8 +7308,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
           "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "encoding": {
           "version": "0.1.13",
@@ -7498,8 +7467,7 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
           "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
@@ -7517,8 +7485,7 @@
           "version": "1.8.1",
           "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
           "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "eth-block-tracker": {
           "version": "3.0.1",
@@ -8050,7 +8017,6 @@
           "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.7.tgz",
           "integrity": "sha512-cDcJJSJ9GMAcURiAWO3DxIEhTL/uWqlQnvgKpuYQzYPrt/izuGU+1ntQmHt0IRq6ADoSYHFnB+aCEFIldjhkMQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "js-sha3": "^0.8.0"
           }
@@ -8260,7 +8226,6 @@
           "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
           "integrity": "sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=",
           "dev": true,
-          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "number-to-bn": "1.7.0"
@@ -8270,8 +8235,7 @@
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
               "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -8289,8 +8253,7 @@
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
           "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "events": {
           "version": "3.2.0",
@@ -8615,8 +8578,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
           "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "file-uri-to-path": {
           "version": "1.0.0",
@@ -8838,15 +8800,13 @@
           "version": "0.5.2",
           "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
           "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "fs-constants": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
           "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "fs-extra": {
           "version": "4.0.3",
@@ -9365,7 +9325,6 @@
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
           "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "depd": "~1.1.2",
             "inherits": "2.0.3",
@@ -9378,8 +9337,7 @@
               "version": "2.0.3",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -9387,8 +9345,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/http-https/-/http-https-1.0.0.tgz",
           "integrity": "sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "http-signature": {
           "version": "1.2.0",
@@ -9406,7 +9363,6 @@
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
           "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
@@ -9822,8 +9778,7 @@
           "version": "0.8.0",
           "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
           "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "js-tokens": {
           "version": "3.0.2",
@@ -10432,8 +10387,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
           "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "lru-cache": {
           "version": "5.1.1",
@@ -10543,8 +10497,7 @@
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
           "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "merge-descriptors": {
           "version": "1.0.1",
@@ -10747,8 +10700,7 @@
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
           "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "mime-db": {
           "version": "1.44.0",
@@ -10769,8 +10721,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
           "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "min-document": {
           "version": "2.19.0",
@@ -10813,7 +10764,6 @@
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
           "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -11002,7 +10952,6 @@
           "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
           "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
           "dev": true,
-          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "strip-hex-prefix": "1.0.0"
@@ -11012,8 +10961,7 @@
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
               "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -11167,7 +11115,6 @@
           "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.4.tgz",
           "integrity": "sha1-IMiM2wwVNxuwQRklfU/dNLCqSfY=",
           "dev": true,
-          "optional": true,
           "requires": {
             "http-https": "^1.0.0"
           }
@@ -11177,7 +11124,6 @@
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
           "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ee-first": "1.1.1"
           }
@@ -11288,7 +11234,6 @@
           "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
           "integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "asn1.js": "^4.0.0",
             "browserify-aes": "^1.0.0",
@@ -11340,8 +11285,7 @@
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
           "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "pascalcase": {
           "version": "0.1.1",
@@ -11618,7 +11562,6 @@
           "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
           "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "dev": true,
-          "optional": true,
           "requires": {
             "end-of-stream": "^1.1.0",
             "once": "^1.3.1"
@@ -11657,15 +11600,13 @@
           "version": "6.7.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
           "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "query-string": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "decode-uri-component": "^0.2.0",
             "object-assign": "^4.1.0",
@@ -11696,15 +11637,13 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
           "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "raw-body": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
           "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
           "dev": true,
-          "optional": true,
           "requires": {
             "bytes": "3.1.0",
             "http-errors": "1.7.2",
@@ -12181,7 +12120,6 @@
           "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
           "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "debug": "2.6.9",
             "depd": "~1.1.2",
@@ -12203,7 +12141,6 @@
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               },
@@ -12212,8 +12149,7 @@
                   "version": "2.0.0",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                   "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                  "dev": true,
-                  "optional": true
+                  "dev": true
                 }
               }
             },
@@ -12221,8 +12157,7 @@
               "version": "2.1.1",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
               "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -12298,8 +12233,7 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
           "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "sha.js": {
           "version": "2.4.11",
@@ -12315,15 +12249,13 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
           "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "simple-get": {
           "version": "2.8.1",
           "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
           "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "decompress-response": "^3.3.0",
             "once": "^1.3.1",
@@ -12602,8 +12534,7 @@
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
           "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "stream-exhaust": {
           "version": "1.0.2",
@@ -12639,8 +12570,7 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
           "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "string-width": {
           "version": "1.0.2",
@@ -12896,7 +12826,6 @@
           "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
           "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
           "dev": true,
-          "optional": true,
           "requires": {
             "bl": "^1.0.0",
             "buffer-alloc": "^1.2.0",
@@ -12911,15 +12840,13 @@
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "readable-stream": {
               "version": "2.3.7",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
               "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -12934,15 +12861,13 @@
               "version": "5.1.2",
               "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
               "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "string_decoder": {
               "version": "1.1.1",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -13023,8 +12948,7 @@
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
           "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "tmp": {
           "version": "0.1.0",
@@ -13049,8 +12973,7 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
           "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "to-fast-properties": {
           "version": "1.0.3",
@@ -13120,8 +13043,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
           "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "tough-cookie": {
           "version": "2.5.0",
@@ -13171,7 +13093,6 @@
           "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
           "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
           "dev": true,
-          "optional": true,
           "requires": {
             "media-typer": "0.3.0",
             "mime-types": "~2.1.24"
@@ -13241,8 +13162,7 @@
           "version": "1.9.1",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
           "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "undertaker": {
           "version": "1.2.1",
@@ -13306,8 +13226,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
           "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "unset-value": {
           "version": "1.0.0",
@@ -13390,8 +13309,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
           "integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "url-to-options": {
           "version": "1.0.1",
@@ -13410,8 +13328,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
           "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "util-deprecate": {
           "version": "1.0.2",
@@ -13473,8 +13390,7 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
           "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "verror": {
           "version": "1.10.0",
@@ -13643,7 +13559,6 @@
           "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.4.tgz",
           "integrity": "sha512-CHc27sMuET2cs1IKrkz7xzmTdMfZpYswe7f0HcuyneTwS1yTlTnHyqjAaTy0ZygAb/x4iaVox+Gvr4oSAqSI+A==",
           "dev": true,
-          "optional": true,
           "requires": {
             "@types/bignumber.js": "^5.0.0",
             "@types/bn.js": "^4.11.4",
@@ -13658,8 +13573,7 @@
               "version": "12.12.53",
               "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.53.tgz",
               "integrity": "sha512-51MYTDTyCziHb70wtGNFRwB4l+5JNvdqzFSkbDvpbftEgVUBEE+T5f7pROhWMp/fxp07oNIEQZd5bbfAH22ohQ==",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -13668,7 +13582,6 @@
           "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.4.tgz",
           "integrity": "sha512-U7wbsK8IbZvF3B7S+QMSNP0tni/6VipnJkB0tZVEpHEIV2WWeBHYmZDnULWcsS/x/jn9yKhJlXIxWGsEAMkjiw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "underscore": "1.9.1",
             "web3-eth-iban": "1.2.4",
@@ -13680,7 +13593,6 @@
           "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.4.tgz",
           "integrity": "sha512-8p9kpL7di2qOVPWgcM08kb+yKom0rxRCMv6m/K+H+yLSxev9TgMbCgMSbPWAHlyiF3SJHw7APFKahK5Z+8XT5A==",
           "dev": true,
-          "optional": true,
           "requires": {
             "underscore": "1.9.1",
             "web3-core-helpers": "1.2.4",
@@ -13694,7 +13606,6 @@
           "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.4.tgz",
           "integrity": "sha512-gEUlm27DewUsfUgC3T8AxkKi8Ecx+e+ZCaunB7X4Qk3i9F4C+5PSMGguolrShZ7Zb6717k79Y86f3A00O0VAZw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "any-promise": "1.3.0",
             "eventemitter3": "3.1.2"
@@ -13705,7 +13616,6 @@
           "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.4.tgz",
           "integrity": "sha512-eZJDjyNTDtmSmzd3S488nR/SMJtNnn/GuwxnMh3AzYCqG3ZMfOylqTad2eYJPvc2PM5/Gj1wAMQcRpwOjjLuPg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "underscore": "1.9.1",
             "web3-core-helpers": "1.2.4",
@@ -13719,7 +13629,6 @@
           "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.4.tgz",
           "integrity": "sha512-3D607J2M8ymY9V+/WZq4MLlBulwCkwEjjC2U+cXqgVO1rCyVqbxZNCmHyNYHjDDCxSEbks9Ju5xqJxDSxnyXEw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "eventemitter3": "3.1.2",
             "underscore": "1.9.1",
@@ -13753,7 +13662,6 @@
           "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.4.tgz",
           "integrity": "sha512-8eLIY4xZKoU3DSVu1pORluAw9Ru0/v4CGdw5so31nn+7fR8zgHMgwbFe0aOqWQ5VU42PzMMXeIJwt4AEi2buFg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "ethers": "4.0.0-beta.3",
             "underscore": "1.9.1",
@@ -13764,22 +13672,19 @@
               "version": "10.17.28",
               "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.28.tgz",
               "integrity": "sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ==",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aes-js": {
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
               "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "elliptic": {
               "version": "6.3.3",
               "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
               "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "bn.js": "^4.4.0",
                 "brorand": "^1.0.1",
@@ -13792,7 +13697,6 @@
               "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.3.tgz",
               "integrity": "sha512-YYPogooSknTwvHg3+Mv71gM/3Wcrx+ZpCzarBj3mqs9njjRkrOo2/eufzhHloOCo3JSoNI4TQJJ6yU5ABm3Uog==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "@types/node": "^10.3.2",
                 "aes-js": "3.0.0",
@@ -13811,7 +13715,6 @@
               "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
               "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "inherits": "^2.0.3",
                 "minimalistic-assert": "^1.0.0"
@@ -13821,29 +13724,25 @@
               "version": "0.5.7",
               "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
               "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "scrypt-js": {
               "version": "2.0.3",
               "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
               "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q=",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "setimmediate": {
               "version": "1.0.4",
               "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
               "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "uuid": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
               "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -13894,7 +13793,6 @@
           "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.4.tgz",
           "integrity": "sha512-b/9zC0qjVetEYnzRA1oZ8gF1OSSUkwSYi5LGr4GeckLkzXP7osEnp9lkO/AQcE4GpG+l+STnKPnASXJGZPgBRQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "@types/bn.js": "^4.11.4",
             "underscore": "1.9.1",
@@ -13929,7 +13827,6 @@
           "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.4.tgz",
           "integrity": "sha512-D9HIyctru/FLRpXakRwmwdjb5bWU2O6UE/3AXvRm6DCOf2e+7Ve11qQrPtaubHfpdW3KWjDKvlxV9iaFv/oTMQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "bn.js": "4.11.8",
             "web3-utils": "1.2.4"
@@ -13939,8 +13836,7 @@
               "version": "4.11.8",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
               "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -13949,7 +13845,6 @@
           "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.4.tgz",
           "integrity": "sha512-5Russ7ZECwHaZXcN3DLuLS7390Vzgrzepl4D87SD6Sn1DHsCZtvfdPIYwoTmKNp69LG3mORl7U23Ga5YxqkICw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "@types/node": "^12.6.1",
             "web3-core": "1.2.4",
@@ -13963,8 +13858,7 @@
               "version": "12.12.53",
               "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.53.tgz",
               "integrity": "sha512-51MYTDTyCziHb70wtGNFRwB4l+5JNvdqzFSkbDvpbftEgVUBEE+T5f7pROhWMp/fxp07oNIEQZd5bbfAH22ohQ==",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -13973,7 +13867,6 @@
           "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.4.tgz",
           "integrity": "sha512-wKOsqhyXWPSYTGbp7ofVvni17yfRptpqoUdp3SC8RAhDmGkX6irsiT9pON79m6b3HUHfLoBilFQyt/fTUZOf7A==",
           "dev": true,
-          "optional": true,
           "requires": {
             "web3-core": "1.2.4",
             "web3-core-method": "1.2.4",
@@ -14014,7 +13907,7 @@
               "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
               "dev": true,
               "requires": {
-                "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+                "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b",
                 "ethereumjs-util": "^5.1.1"
               }
             },
@@ -14245,7 +14138,6 @@
           "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.4.tgz",
           "integrity": "sha512-dzVCkRrR/cqlIrcrWNiPt9gyt0AZTE0J+MfAu9rR6CyIgtnm1wFUVVGaxYRxuTGQRO4Dlo49gtoGwaGcyxqiTw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "web3-core-helpers": "1.2.4",
             "xhr2-cookies": "1.1.0"
@@ -14256,7 +14148,6 @@
           "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.4.tgz",
           "integrity": "sha512-8J3Dguffin51gckTaNrO3oMBo7g+j0UNk6hXmdmQMMNEtrYqw4ctT6t06YOf9GgtOMjSAc1YEh3LPrvgIsR7og==",
           "dev": true,
-          "optional": true,
           "requires": {
             "oboe": "2.1.4",
             "underscore": "1.9.1",
@@ -14268,7 +14159,6 @@
           "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.4.tgz",
           "integrity": "sha512-F/vQpDzeK+++oeeNROl1IVTufFCwCR2hpWe5yRXN0ApLwHqXrMI7UwQNdJ9iyibcWjJf/ECbauEEQ8CHgE+MYQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "@web3-js/websocket": "^1.0.29",
             "underscore": "1.9.1",
@@ -14293,7 +14183,6 @@
           "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.4.tgz",
           "integrity": "sha512-+S86Ip+jqfIPQWvw2N/xBQq5JNqCO0dyvukGdJm8fEWHZbckT4WxSpHbx+9KLEWY4H4x9pUwnoRkK87pYyHfgQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "bn.js": "4.11.8",
             "eth-lib": "0.2.7",
@@ -14309,15 +14198,13 @@
               "version": "4.11.8",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
               "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "eth-lib": {
               "version": "0.2.7",
               "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
               "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "bn.js": "^4.11.6",
                 "elliptic": "^6.4.0",
@@ -14431,7 +14318,6 @@
           "resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.1.0.tgz",
           "integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "buffer-to-arraybuffer": "^0.0.5",
             "object-assign": "^4.1.1",
@@ -14447,7 +14333,6 @@
           "resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.3.tgz",
           "integrity": "sha512-YUBytBsuwgitWtdRzXDDkWAXzhdGB8bYm0sSzMPZT7Z2MBjMSTHFsyCT1yCRATY+XC69DUrQraRAEgcoCRaIPg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "xhr-request": "^1.1.0"
           }
@@ -14457,7 +14342,6 @@
           "resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
           "integrity": "sha1-fXdEnQmZGX8VXLc7I99yUF7YnUg=",
           "dev": true,
-          "optional": true,
           "requires": {
             "cookiejar": "^2.1.1"
           }
@@ -14466,8 +14350,7 @@
           "version": "1.8.0",
           "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
           "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "xtend": {
           "version": "4.0.2",
@@ -16684,7 +16567,6 @@
           "resolved": false,
           "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -18018,8 +17900,7 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "loose-envify": {
           "version": "1.3.1",


### PR DESCRIPTION
* Remove `isValidPubKey` check at registry call.
* Add precompile gas cost calculations
    * Send exact amount of gas to precompile calls
* `callSuccess` mostly indicates that one of points (can be G1 or G2) are not on curve or on correct subgroup.
* Batches using Invalid pubkeys can be slashed calling same path with invalid signature aggregation

```
        Types.Result result = transfer.checkSignature(
            target.commitment.body.signature,
            signatureProof,
            target.commitment.stateRoot,
            target.commitment.body.accountRoot,
            appID,
            target.commitment.body.txs
        );

        if (result != Types.Result.Ok) {
            invalidBatchMarker = batchID;
            slashAndRollback();
        }
```

`result` must return __not Ok__ if any of senders pubkey is invalid

## Problem within this PR
* We want to detect that precompile call in another saying the signature verification fails because of a point not being on curve or in correct subgroup. In order to make gas estimation work well for a tx that goes through unsuccesful precompile call, gas amount that is sent along precompile call is hardcoded. Problem is that we before experienced precompile gas cost change with EIP 1108.