### PR TITLE
you can stake more than required

### DIFF
--- a/contracts/rollup/StakeManager.sol
+++ b/contracts/rollup/StakeManager.sol
@@ -7,7 +7,7 @@ contract StakeManager {
     mapping(uint256 => uint256) private stakes;
 
     function stake(uint256 batchID, uint256 stakeAmount) internal {
-        require(msg.value == stakeAmount, "StakeManager: wrong stake amount");
+        require(msg.value >= stakeAmount, "StakeManager: wrong stake amount");
         stakes[batchID] = stakeAmount;
     }
 


### PR DESCRIPTION
This main purpose of this change is to make the client dev easier to test a huge amount of staking before getting an exact stake value