### PR TITLE
Revamp state tree again

### DIFF
--- a/test/create2transfer.test.ts
+++ b/test/create2transfer.test.ts
@@ -169,9 +169,10 @@ describe("Rollup Create2Transfer Commitment", () => {
 
         for (const tx of txs) {
             const preRoot = stateTree.root;
-            const { proofs, safe } = stateTree.processCreate2Transfer(tx);
-            const [senderProof, receiverProof] = proofs;
-            assert.isTrue(safe);
+            const [
+                senderProof,
+                receiverProof
+            ] = stateTree.processCreate2Transfer(tx);
             const postRoot = stateTree.root;
             const {
                 0: processedRoot,

--- a/test/rollupTransfer.test.ts
+++ b/test/rollupTransfer.test.ts
@@ -118,9 +118,7 @@ describe("Rollup Transfer Commitment", () => {
         const txs = txTransferFactory(states, COMMIT_SIZE);
         for (const tx of txs) {
             const preRoot = stateTree.root;
-            const { proofs, safe } = stateTree.processTransfer(tx);
-            const [senderProof, receiverProof] = proofs;
-            assert.isTrue(safe);
+            const [senderProof, receiverProof] = stateTree.processTransfer(tx);
             const postRoot = stateTree.root;
             const {
                 0: processedRoot,

--- a/ts/exceptions.ts
+++ b/ts/exceptions.ts
@@ -3,3 +3,15 @@ export class HubbleError extends Error {}
 export class EncodingError extends HubbleError {}
 
 export class MismatchByteLength extends HubbleError {}
+
+class StateTreeExceptions extends HubbleError {}
+
+export class SenderNotExist extends StateTreeExceptions {}
+
+export class ReceiverNotExist extends StateTreeExceptions {}
+
+export class StateAlreadyExist extends StateTreeExceptions {}
+
+export class WrongTokenType extends StateTreeExceptions {}
+
+export class InsufficientFund extends StateTreeExceptions {}

--- a/ts/state.ts
+++ b/ts/state.ts
@@ -39,12 +39,16 @@ export class State {
 
     // TODO add optional params for pubkey and stateID
     public clone() {
-        return new State(
+        const state = new State(
             this.pubkeyIndex,
             this.tokenType,
             this.balance,
             this.nonce
         );
+        state.setStateID(this.stateID);
+        state.publicKey = this.publicKey;
+        state.secretKey = this.secretKey;
+        return state;
     }
 
     public stateID = -1;

--- a/ts/stateTree.ts
+++ b/ts/stateTree.ts
@@ -147,7 +147,7 @@ export class StateTree {
         if (raiseError) {
             return { proofs: Array.from(generator), safe: true };
         } else {
-            return processNoRaise(generator, txs.length + 1);
+            return processNoRaise(generator, txs.length * 2 + 1);
         }
     }
     private *_processCreate2TransferCommit(
@@ -186,7 +186,7 @@ export class StateTree {
         if (raiseError) {
             return { proofs: Array.from(generator), safe: true };
         } else {
-            return processNoRaise(generator, txs.length + 1);
+            return processNoRaise(generator, txs.length * 2 + 1);
         }
     }
     private *_processMassMigrationCommit(


### PR DESCRIPTION
### What's wrong

- In one situation we want the state tree to append placeholder states and witnesses when a state transition fails so that we can simulate a fraudulent commitment.
- In other situations, we want to debug why a certain state transition fails.

### How can we fix that

`stateTree.processTransferCommit(..., raiseError: true)`

We add a raiseError arg in the API. If the arg is set, then the function raises errors, otherwise, it silently appends dummy proofs.

This is an example error message I'm seeing in my other local branch.
```
1) Integration Test
       Getting new users via Create to transfer:
     Error: balance: 20000000, tx amount+fee: 110000000
      at StateTree.processSender (ts/stateTree.ts:274:19)
      at StateTree.processCreate2Transfer (ts/stateTree.ts:245:34)
      at StateTree._processCreate2TransferCommit (ts/stateTree.ts:159:55)
      at _processCreate2TransferCommit.next (<anonymous>)
      at Function.from (<anonymous>)
      at StateTree.processCreate2TransferCommit (ts/stateTree.ts:187:36)
      at Context.<anonymous> (test/integration.test.ts:219:40)
```
We achieve the functionality by using the Generator. Say, we have 10 Transfer txs, we expect to have 21 proofs (10 sender+ 10 receiver + fee). So if the 5th tx is a bad state transition and an error is raised, the generator can still successfully yield valid proofs for the 4 good txs.
