### PR TITLE
Better genesis 2

### DIFF
--- a/scripts/benchmark.ts
+++ b/scripts/benchmark.ts
@@ -4,6 +4,7 @@ import { TESTING_PARAMS } from "../ts/constants";
 import { deployAll } from "../ts/deploy";
 import { serialize, TxTransfer } from "../ts/tx";
 import { execSync } from "child_process";
+import { constants } from "ethers";
 
 const txPerCommitment = 32;
 const commitmentsPerBatch = 32;
@@ -12,8 +13,12 @@ const blockGasLimit = 12500000;
 
 async function main() {
     const [signer, ...rest] = await ethers.getSigners();
+    const parameters = TESTING_PARAMS;
 
-    const constracts = await deployAll(signer, TESTING_PARAMS);
+    const constracts = await deployAll(signer, {
+        ...TESTING_PARAMS,
+        GENESIS_STATE_ROOT: constants.HashZero
+    });
     let commitments = [];
     for (let i = 0; i < commitmentsPerBatch; i++) {
         let commitment = TransferCommitment.new(ethers.constants.HashZero);

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -6,6 +6,8 @@ import { toWei } from "../ts/utils";
 import { BlsAccountRegistry } from "../types/ethers-contracts/BlsAccountRegistry";
 import fs from "fs";
 import { PRODUCTION_PARAMS } from "../ts/constants";
+import { StateTree } from "../ts/stateTree";
+import { State } from "../ts/state";
 
 const argv = require("minimist")(process.argv.slice(2), {
     string: ["url", "root", "pubkeys"]
@@ -17,6 +19,17 @@ const argv = require("minimist")(process.argv.slice(2), {
     --pubkeys 06642b1af0ec2f7369126b3e45aaf11a050a26e2111150b319c4ca2f4a8d48c62442e01b651ce469632972f06c4d5d092da2cde3d42c0ead5ebeed8646d72b3f1f09c41c70cbdd8779920b4a3b15e6c7c518c5fdb93fdaed7a49c59b1f4d1e210aafa7a17239c9df9053ca4e71f10fb9f7b0f219e12e300676a756463253c287,2a7575b1bddf2c2b25f976788baae059ea410f589f0c244e1554d6f6f5398b6a1b997670d19c26c33ad1c61e21bd2742565518e0deafb105e7718de983bf757a0770cb4889aabb6f4897534f4770fce4b76f39b2cc8ed63b22e55ebf7e87a96001bbabd11ca55585bc0c016ad058a69c682cbe102a4b91f6084c71c857509dac
 */
 
+function getDefaultGenesisRoot(parameters: DeploymentParameters) {
+    const stateTree = StateTree.new(parameters.MAX_DEPTH);
+    const LARGE_AMOUNT = 1000000000;
+    const state0 = State.new(0, 0, LARGE_AMOUNT, 0);
+    state0.setStateID(0);
+    const state1 = State.new(1, 0, LARGE_AMOUNT, 0);
+    state1.setStateID(1);
+    stateTree.createStateBulk([state0, state1]);
+    return stateTree.root;
+}
+
 async function main() {
     const provider = new ethers.providers.JsonRpcProvider(argv.url);
     const signer = provider.getSigner();
@@ -25,7 +38,8 @@ async function main() {
     // ).connect(provider);
 
     const parameters = PRODUCTION_PARAMS;
-    parameters.GENESIS_STATE_ROOT = argv.root;
+    parameters.GENESIS_STATE_ROOT =
+        argv.root || getDefaultGenesisRoot(parameters);
 
     const contracts = await deployAll(signer, parameters, true);
     let addresses: { [key: string]: string } = {};

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -2,12 +2,10 @@ import { ethers } from "ethers";
 import { allContracts } from "../ts/allContractsInterfaces";
 import { deployAll } from "../ts/deploy";
 import { DeploymentParameters } from "../ts/interfaces";
-import { toWei } from "../ts/utils";
 import { BlsAccountRegistry } from "../types/ethers-contracts/BlsAccountRegistry";
 import fs from "fs";
 import { PRODUCTION_PARAMS } from "../ts/constants";
 import { StateTree } from "../ts/stateTree";
-import { State } from "../ts/state";
 
 const argv = require("minimist")(process.argv.slice(2), {
     string: ["url", "root", "pubkeys"]
@@ -21,12 +19,8 @@ const argv = require("minimist")(process.argv.slice(2), {
 
 function getDefaultGenesisRoot(parameters: DeploymentParameters) {
     const stateTree = StateTree.new(parameters.MAX_DEPTH);
-    const LARGE_AMOUNT = 1000000000;
-    const state0 = State.new(0, 0, LARGE_AMOUNT, 0);
-    state0.setStateID(0);
-    const state1 = State.new(1, 0, LARGE_AMOUNT, 0);
-    state1.setStateID(1);
-    stateTree.createStateBulk([state0, state1]);
+    // An completely empty genesis state
+    // Can add states here
     return stateTree.root;
 }
 

--- a/test/MassMigration.test.ts
+++ b/test/MassMigration.test.ts
@@ -14,6 +14,7 @@ import { Result } from "../ts/interfaces";
 import { Tree } from "../ts/tree";
 import { mineBlocks } from "../ts/utils";
 import { expectRevert } from "../ts/utils";
+import { constants } from "ethers";
 
 describe("Mass Migrations", async function() {
     const tokenID = 0;
@@ -28,7 +29,10 @@ describe("Mass Migrations", async function() {
 
     beforeEach(async function() {
         const [signer] = await ethers.getSigners();
-        contracts = await deployAll(signer, TESTING_PARAMS);
+        contracts = await deployAll(signer, {
+            ...TESTING_PARAMS,
+            GENESIS_STATE_ROOT: constants.HashZero
+        });
         const { rollup, blsAccountRegistry } = contracts;
         mcl.setDomainHex(await rollup.appID());
 

--- a/test/deposit.test.ts
+++ b/test/deposit.test.ts
@@ -66,7 +66,10 @@ describe("DepositManager", async function() {
     let tokenID: number;
     beforeEach(async function() {
         const [signer] = await ethers.getSigners();
-        contracts = await deployAll(signer, TESTING_PARAMS);
+        contracts = await deployAll(signer, {
+            ...TESTING_PARAMS,
+            GENESIS_STATE_ROOT: constants.HashZero
+        });
         const { testToken, tokenRegistry, depositManager } = contracts;
         tokenID = (await tokenRegistry.nextTokenID()).toNumber() - 1;
         await testToken.approve(depositManager.address, LARGE_AMOUNT_OF_TOKEN);

--- a/test/rollupCreate2Transfer.test.ts
+++ b/test/rollupCreate2Transfer.test.ts
@@ -13,6 +13,7 @@ import {
     Create2TransferCommitment
 } from "../ts/commitments";
 import { USDT } from "../ts/decimal";
+import { constants } from "ethers";
 
 const DOMAIN =
     "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
@@ -32,7 +33,10 @@ describe("Rollup Create2Transfer", async function() {
 
     beforeEach(async function() {
         const accounts = await ethers.getSigners();
-        contracts = await deployAll(accounts[0], TESTING_PARAMS);
+        contracts = await deployAll(accounts[0], {
+            ...TESTING_PARAMS,
+            GENESIS_STATE_ROOT: constants.HashZero
+        });
         stateTree = new StateTree(TESTING_PARAMS.MAX_DEPTH);
         const registryContract = contracts.blsAccountRegistry;
         registry = await AccountRegistry.new(registryContract);

--- a/ts/commitments.ts
+++ b/ts/commitments.ts
@@ -1,5 +1,6 @@
 import { BigNumberish, BytesLike, ethers } from "ethers";
 import { Rollup } from "../types/ethers-contracts/Rollup";
+import { ZERO_BYTES32 } from "./constants";
 import { Wei } from "./interfaces";
 import { Tree } from "./tree";
 
@@ -41,6 +42,21 @@ abstract class Commitment {
             stateRoot: this.stateRoot,
             bodyRoot: this.bodyRoot
         };
+    }
+}
+
+export class GenesisCommitment extends Commitment {
+    get bodyRoot() {
+        return ZERO_BYTES32;
+    }
+    public toSolStruct() {
+        return { stateRoot: this.stateRoot, body: {} };
+    }
+    public toBatch(): Batch {
+        return new Batch([this]);
+    }
+    static getProof(stateRoot: BytesLike): CommitmentInclusionProof {
+        return new GenesisCommitment(stateRoot).toBatch().proofCompressed(0);
     }
 }
 

--- a/ts/commitments.ts
+++ b/ts/commitments.ts
@@ -55,9 +55,12 @@ export class GenesisCommitment extends Commitment {
     public toBatch(): Batch {
         return new Batch([this]);
     }
-    static getProof(stateRoot: BytesLike): CommitmentInclusionProof {
-        return new GenesisCommitment(stateRoot).toBatch().proofCompressed(0);
-    }
+}
+
+export function getGenesisProof(
+    stateRoot: BytesLike
+): CommitmentInclusionProof {
+    return new GenesisCommitment(stateRoot).toBatch().proofCompressed(0);
 }
 
 export class TransferCommitment extends Commitment {

--- a/ts/deploy.ts
+++ b/ts/deploy.ts
@@ -26,6 +26,7 @@ import { BurnAuctionFactory } from "../types/ethers-contracts/BurnAuctionFactory
 import { BurnAuction } from "../types/ethers-contracts/BurnAuction";
 import { ProofOfBurnFactory } from "../types/ethers-contracts/ProofOfBurnFactory";
 import { ProofOfBurn } from "../types/ethers-contracts/ProofOfBurn";
+import { GenesisNotSpecified } from "./exceptions";
 
 async function waitAndRegister(
     contract: Contract,
@@ -197,8 +198,8 @@ export async function deployAll(
         await paramManager.depositManager()
     );
 
-    if (!parameters.GENESIS_STATE_ROOT)
-        throw Error("GENESIS_STATE_ROOT not specified!");
+    if (!parameters.GENESIS_STATE_ROOT) throw new GenesisNotSpecified();
+
     // deploy Rollup core
     const rollup = await new RollupFactory(allLinkRefs, signer).deploy(
         nameRegistry.address,

--- a/ts/exceptions.ts
+++ b/ts/exceptions.ts
@@ -4,6 +4,8 @@ export class EncodingError extends HubbleError {}
 
 export class MismatchByteLength extends HubbleError {}
 
+export class GenesisNotSpecified extends HubbleError {}
+
 class StateTreeExceptions extends HubbleError {}
 
 export class SenderNotExist extends StateTreeExceptions {}

--- a/ts/utils.ts
+++ b/ts/utils.ts
@@ -62,50 +62,6 @@ export async function mineBlocks(
     }
 }
 
-export function getParentLeaf(left: string, right: string) {
-    return ethers.utils.solidityKeccak256(
-        ["bytes32", "bytes32"],
-        [left, right]
-    );
-}
-
-export function defaultHashes(depth: number) {
-    const hashes = [];
-    hashes[0] = keccak256(constants.HashZero);
-    for (let i = 1; i < depth; i++) {
-        hashes[i] = getParentLeaf(hashes[i - 1], hashes[i - 1]);
-    }
-    return hashes;
-}
-
-export async function merklise(dataLeaves: string[], maxDepth: number) {
-    let nodes: string[] = dataLeaves.slice();
-    const defaultHashesForLeaves: string[] = defaultHashes(maxDepth);
-    let odd = nodes.length & 1;
-    let n = (nodes.length + 1) >> 1;
-    let level = 0;
-    while (true) {
-        let i = 0;
-        for (; i < n - odd; i++) {
-            let j = i << 1;
-            nodes[i] = getParentLeaf(nodes[j], nodes[j + 1]);
-        }
-        if (odd == 1) {
-            nodes[i] = getParentLeaf(
-                nodes[i << 1],
-                defaultHashesForLeaves[level]
-            );
-        }
-        if (n == 1) {
-            break;
-        }
-        odd = n & 1;
-        n = (n + 1) >> 1;
-        level += 1;
-    }
-    return nodes[0];
-}
-
 export async function expectRevert(
     tx: Promise<ContractTransaction>,
     revertReason: string


### PR DESCRIPTION
### Behavior change

1. We don't create genesis root in the ts/deploy.ts now. Genesis must be explicitly specified in the deployment parameters, otherwise ts/deploy.ts raises an error.
2. The scripts/deploy.ts has default genesis root if the genesis root is not specified in the arg. So client testing can be like the good old days. Note that the new genesis states have a large amount of balance.