### PR TITLE
Rename TestToken to ExampleToken

### DIFF
--- a/contracts/libs/ParamManager.sol
+++ b/contracts/libs/ParamManager.sol
@@ -9,8 +9,8 @@ library ParamManager {
         return keccak256("withdraw_manager");
     }
 
-    function testToken() public pure returns (bytes32) {
-        return keccak256("test_token");
+    function exampleToken() public pure returns (bytes32) {
+        return keccak256("example_token");
     }
 
     function chooser() public pure returns (bytes32) {

--- a/contracts/test/ExampleToken.sol
+++ b/contracts/test/ExampleToken.sol
@@ -3,10 +3,7 @@ pragma solidity ^0.5.15;
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/ownership/Ownable.sol";
 
-/**
- * @title TestToken is a basic ERC20 Token
- */
-contract TestToken is ERC20, Ownable {
+contract ExampleToken is ERC20, Ownable {
     /**
      * @dev assign totalSupply to account creating this contract */
     constructor() public {

--- a/test/MassMigration.test.ts
+++ b/test/MassMigration.test.ts
@@ -145,7 +145,7 @@ describe("Mass Migrations", async function() {
         );
     });
     it("submit a batch, finalize, and withdraw", async function() {
-        const { rollup, withdrawManager, testToken, vault } = contracts;
+        const { rollup, withdrawManager, exampleToken, vault } = contracts;
         const feeReceiver = Alice.stateID;
         const tx = new TxMassMigration(
             Alice.stateID,
@@ -194,7 +194,7 @@ describe("Mass Migrations", async function() {
 
         // We cheat here a little bit by sending token to the vault manually.
         // Ideally the tokens of the vault should come from the deposits
-        await testToken.transfer(vault.address, tx.amount);
+        await exampleToken.transfer(vault.address, tx.amount);
 
         const txProcess = await withdrawManager.processWithdrawCommitment(
             batchId,

--- a/test/deposit.test.ts
+++ b/test/deposit.test.ts
@@ -70,9 +70,12 @@ describe("DepositManager", async function() {
             ...TESTING_PARAMS,
             GENESIS_STATE_ROOT: constants.HashZero
         });
-        const { testToken, tokenRegistry, depositManager } = contracts;
+        const { exampleToken, tokenRegistry, depositManager } = contracts;
         tokenID = (await tokenRegistry.nextTokenID()).toNumber() - 1;
-        await testToken.approve(depositManager.address, LARGE_AMOUNT_OF_TOKEN);
+        await exampleToken.approve(
+            depositManager.address,
+            LARGE_AMOUNT_OF_TOKEN
+        );
     });
     it("should allow depositing 2 leaves in a subtree and merging it", async function() {
         const { depositManager } = contracts;

--- a/ts/allContractsInterfaces.ts
+++ b/ts/allContractsInterfaces.ts
@@ -3,7 +3,7 @@ import { NameRegistry } from "../types/ethers-contracts/NameRegistry";
 import { TokenRegistry } from "../types/ethers-contracts/TokenRegistry";
 import { Pob } from "../types/ethers-contracts/Pob";
 import { Transfer } from "../types/ethers-contracts/Transfer";
-import { TestToken } from "../types/ethers-contracts/TestToken";
+import { ExampleToken } from "../types/ethers-contracts/ExampleToken";
 import { DepositManager } from "../types/ethers-contracts/DepositManager";
 import { Rollup } from "../types/ethers-contracts/Rollup";
 import { BlsAccountRegistry } from "../types/ethers-contracts/BlsAccountRegistry";
@@ -31,7 +31,7 @@ export interface allContracts {
     massMigration: MassMigration;
     create2Transfer: Create2Transfer;
     chooser: Pob | BurnAuction;
-    testToken: TestToken;
+    exampleToken: ExampleToken;
     spokeRegistry: SpokeRegistry;
     vault: Vault;
     depositManager: DepositManager;

--- a/ts/deploy.ts
+++ b/ts/deploy.ts
@@ -4,7 +4,7 @@ import { NameRegistry } from "../types/ethers-contracts/NameRegistry";
 import { TokenRegistryFactory } from "../types/ethers-contracts/TokenRegistryFactory";
 import { TransferFactory } from "../types/ethers-contracts/TransferFactory";
 import { MassMigrationFactory } from "../types/ethers-contracts/MassMigrationFactory";
-import { TestTokenFactory } from "../types/ethers-contracts/TestTokenFactory";
+import { ExampleTokenFactory } from "../types/ethers-contracts/ExampleTokenFactory";
 import { DepositManagerFactory } from "../types/ethers-contracts/DepositManagerFactory";
 import { RollupFactory } from "../types/ethers-contracts/RollupFactory";
 import { BlsAccountRegistryFactory } from "../types/ethers-contracts/BlsAccountRegistryFactory";
@@ -153,17 +153,17 @@ export async function deployAll(
         await paramManager.create2Transfer()
     );
 
-    // deploy test token
-    const testToken = await new TestTokenFactory(signer).deploy();
+    // deploy example token
+    const exampleToken = await new ExampleTokenFactory(signer).deploy();
     await waitAndRegister(
-        testToken,
-        "testToken",
+        exampleToken,
+        "exampleToken",
         verbose,
         nameRegistry,
-        await paramManager.testToken()
+        await paramManager.exampleToken()
     );
-    await tokenRegistry.requestRegistration(testToken.address);
-    await tokenRegistry.finaliseRegistration(testToken.address);
+    await tokenRegistry.requestRegistration(exampleToken.address);
+    await tokenRegistry.finaliseRegistration(exampleToken.address);
 
     const spokeRegistry = await new SpokeRegistryFactory(signer).deploy();
     await waitAndRegister(
@@ -245,7 +245,7 @@ export async function deployAll(
         massMigration,
         create2Transfer,
         chooser,
-        testToken,
+        exampleToken,
         spokeRegistry,
         vault,
         depositManager,


### PR DESCRIPTION
Just don't want this in the audit scope. 

When time permits we might want to remove this contract from the deployment script.