### PR TITLE
Rename zero/empty state

### DIFF
--- a/contracts/libs/Transition.sol
+++ b/contracts/libs/Transition.sol
@@ -96,7 +96,7 @@ library Transition {
         uint256 tokenID,
         Types.StateMerkleProof memory proof
     ) internal pure returns (bytes memory encodedState, bytes32 newRoot) {
-        // Validate we are creating on a zero state
+        // Validate we are creating on a empty state
         require(
             MerkleTree.verify(
                 stateRoot,

--- a/ts/state.ts
+++ b/ts/state.ts
@@ -11,9 +11,9 @@ export interface StateSolStruct {
 }
 
 /**
- * @dev this is not an zero state leaf contrarily this is a legit state!
+ * @dev this is not an empty state leaf contrarily this is a legit state!
  */
-export const EMPTY_STATE: StateSolStruct = {
+export const ZERO_STATE: StateSolStruct = {
     pubkeyID: 0,
     tokenID: 0,
     balance: 0,

--- a/ts/stateTree.ts
+++ b/ts/stateTree.ts
@@ -1,5 +1,5 @@
 import { Hasher, Tree } from "./tree";
-import { State, EMPTY_STATE, StateSolStruct } from "./state";
+import { State, ZERO_STATE, StateSolStruct } from "./state";
 import { TxTransfer, TxMassMigration, TxCreate2Transfer } from "./tx";
 import { BigNumber, constants } from "ethers";
 import { ZERO_BYTES32 } from "./constants";
@@ -24,7 +24,7 @@ const PLACEHOLDER_PROOF_WITNESS = Array(STATE_WITNESS_LENGHT).fill(
 );
 
 const PLACEHOLDER_SOL_STATE_PROOF: SolStateMerkleProof = {
-    state: EMPTY_STATE,
+    state: ZERO_STATE,
     witness: PLACEHOLDER_PROOF_WITNESS
 };
 
@@ -257,7 +257,7 @@ export class StateTree {
         postState: State
     ): SolStateMerkleProof {
         const state = this.states[stateIndex];
-        const preStateStruct = state ? state.toSolStruct() : EMPTY_STATE;
+        const preStateStruct = state ? state.toSolStruct() : ZERO_STATE;
         const witness = this.stateTree.witness(stateIndex).nodes;
         this.states[stateIndex] = postState;
         this.stateTree.updateSingle(stateIndex, postState.toStateLeaf());


### PR DESCRIPTION
### What's wrong

Two situations of state leaf could be confusing:

- `keccak(abi.encode(state.pubkeyID, state.tokenID, state.balance, state.nonce))` is `keccak(abi.encode(0, 0, 0, 0))`
- `keccak(abi.encode(0))`

I propose we call the former a zero leaf, and the latter an empty leaf or a null leaf. The reason is if we treat the properties of the state as a vector of values, the first case is like a zero vector and the second case is like an empty set.

I believe we used to call the second case a zero state because we call that hash a zero_hash. But we could replace that hash with other Nothing-up-my-sleeve numbers. 