### PR TITLE
Revamp state tree 3

### DIFF
--- a/test/create2transfer.test.ts
+++ b/test/create2transfer.test.ts
@@ -162,13 +162,14 @@ describe("Rollup Create2Transfer Commitment", () => {
 
         // concat newstates with the global obj
         states = states.concat(newStates);
+        const tokenID = states[0].tokenID;
 
         for (const tx of txs) {
             const preRoot = stateTree.root;
             const [
                 senderProof,
                 receiverProof
-            ] = stateTree.processCreate2Transfer(tx);
+            ] = stateTree.processCreate2Transfer(tx, tokenID);
             const postRoot = stateTree.root;
             const {
                 0: processedRoot,
@@ -176,7 +177,7 @@ describe("Rollup Create2Transfer Commitment", () => {
             } = await rollup.testProcessCreate2Transfer(
                 preRoot,
                 tx,
-                states[0].tokenID,
+                tokenID,
                 senderProof,
                 receiverProof
             );

--- a/test/create2transfer.test.ts
+++ b/test/create2transfer.test.ts
@@ -98,18 +98,14 @@ describe("Rollup Create2Transfer Commitment", () => {
         const signature = aggregate(signatures).sol;
         const serialized = serialize(txs);
 
-        // Need post stateWitnesses
-        const postStates = txs.map(tx => stateTree.getState(tx.fromIndex));
-        const stateWitnesses = txs.map(tx =>
-            stateTree.getStateWitness(tx.fromIndex)
-        );
+        const postProofs = txs.map(tx => stateTree.getState(tx.fromIndex));
 
         const postStateRoot = stateTree.root;
         const accountRoot = registry.root();
 
         const proof = {
-            states: postStates,
-            stateWitnesses,
+            states: postProofs.map(proof => proof.state),
+            stateWitnesses: postProofs.map(proof => proof.witness),
             pubkeysSender,
             pubkeyWitnessesSender,
             pubkeysReceiver: pubkeysReceiver,

--- a/test/rollupMassMigration.test.ts
+++ b/test/rollupMassMigration.test.ts
@@ -67,17 +67,14 @@ describe("Rollup Mass Migration", () => {
         const serialized = serialize(txs);
 
         // Need post stateWitnesses
-        const postStates = txs.map(tx => stateTree.getState(tx.fromIndex));
-        const stateWitnesses = txs.map(tx =>
-            stateTree.getStateWitness(tx.fromIndex)
-        );
+        const postProofs = txs.map(tx => stateTree.getState(tx.fromIndex));
 
         const postStateRoot = stateTree.root;
         const accountRoot = registry.root();
 
         const proof = {
-            states: postStates,
-            stateWitnesses,
+            states: postProofs.map(proof => proof.state),
+            stateWitnesses: postProofs.map(proof => proof.witness),
             pubkeys,
             pubkeyWitnesses
         };

--- a/test/rollupTransfer.test.ts
+++ b/test/rollupTransfer.test.ts
@@ -113,9 +113,13 @@ describe("Rollup Transfer Commitment", () => {
 
     it("transfer commitment: processTx", async function() {
         const txs = txTransferFactory(states, COMMIT_SIZE);
+        const tokenID = states[0].tokenID;
         for (const tx of txs) {
             const preRoot = stateTree.root;
-            const [senderProof, receiverProof] = stateTree.processTransfer(tx);
+            const [senderProof, receiverProof] = stateTree.processTransfer(
+                tx,
+                tokenID
+            );
             const postRoot = stateTree.root;
             const {
                 0: processedRoot,
@@ -123,7 +127,7 @@ describe("Rollup Transfer Commitment", () => {
             } = await rollup.testProcessTransfer(
                 preRoot,
                 tx,
-                states[0].tokenID,
+                tokenID,
                 senderProof,
                 receiverProof
             );

--- a/test/rollupTransfer.test.ts
+++ b/test/rollupTransfer.test.ts
@@ -66,17 +66,14 @@ describe("Rollup Transfer Commitment", () => {
         const serialized = serialize(txs);
 
         // Need post stateWitnesses
-        const postStates = txs.map(tx => stateTree.getState(tx.fromIndex));
-        const stateWitnesses = txs.map(tx =>
-            stateTree.getStateWitness(tx.fromIndex)
-        );
+        const postProofs = txs.map(tx => stateTree.getState(tx.fromIndex));
 
         const postStateRoot = stateTree.root;
         const accountRoot = registry.root();
 
         const proof = {
-            states: postStates,
-            stateWitnesses,
+            states: postProofs.map(proof => proof.state),
+            stateWitnesses: postProofs.map(proof => proof.witness),
             pubkeys,
             pubkeyWitnesses
         };

--- a/ts/state.ts
+++ b/ts/state.ts
@@ -4,23 +4,6 @@ import { BigNumber, BigNumberish, ethers } from "ethers";
 import { solidityPack } from "ethers/lib/utils";
 import { BlsSignerInterface, NullBlsSinger, BlsSigner } from "./blsSigner";
 
-export interface StateSolStruct {
-    pubkeyID: number;
-    tokenID: number;
-    balance: number;
-    nonce: number;
-}
-
-/**
- * @dev this is not an empty state leaf contrarily this is a legit state!
- */
-export const ZERO_STATE: StateSolStruct = {
-    pubkeyID: 0,
-    tokenID: 0,
-    balance: 0,
-    nonce: 0
-};
-
 export class State {
     public signer: BlsSignerInterface = new NullBlsSinger();
     public static new(
@@ -84,13 +67,6 @@ export class State {
             [this.pubkeyID, this.tokenID, this.balance, this.nonce]
         );
     }
-
-    public toSolStruct(): StateSolStruct {
-        return {
-            pubkeyID: this.pubkeyID,
-            tokenID: this.tokenID,
-            balance: this.balance.toNumber(),
-            nonce: this.nonce
-        };
-    }
 }
+
+export const ZERO_STATE = State.new(0, 0, 0, 0);


### PR DESCRIPTION
- More abstraction on the stateTree. At the core, all operation is just `getState` or `updateState`, or the two combined.
- Remove StateSolStruct, the State class itself is enough to work with the contract
- Handles the tokenID validation correctly, they mirror the contract now.

