### PR TITLE
Moving the signing methods from State to User

### DIFF
--- a/ts/blsSigner.ts
+++ b/ts/blsSigner.ts
@@ -32,6 +32,8 @@ export class NullBlsSinger implements BlsSignerInterface {
     }
 }
 
+export const nullBlsSigner = new NullBlsSinger();
+
 export class BlsSigner implements BlsSignerInterface {
     static new(domain: Domain) {
         const secret = randFr();

--- a/ts/constants.ts
+++ b/ts/constants.ts
@@ -2,7 +2,7 @@ import { DeploymentParameters } from "./interfaces";
 import { toWei } from "./utils";
 
 export const TESTING_PARAMS: DeploymentParameters = {
-    MAX_DEPTH: 4,
+    MAX_DEPTH: 8,
     MAX_DEPOSIT_SUBTREE_DEPTH: 1,
     STAKE_AMOUNT: toWei("0.1"),
     BLOCKS_TO_FINALISE: 5,

--- a/ts/exceptions.ts
+++ b/ts/exceptions.ts
@@ -10,6 +10,8 @@ export class UserNotExist extends HubbleError {}
 
 class StateTreeExceptions extends HubbleError {}
 
+export class ExceedTreeSize extends StateTreeExceptions {}
+
 export class SenderNotExist extends StateTreeExceptions {}
 
 export class ReceiverNotExist extends StateTreeExceptions {}

--- a/ts/exceptions.ts
+++ b/ts/exceptions.ts
@@ -6,6 +6,8 @@ export class MismatchByteLength extends HubbleError {}
 
 export class GenesisNotSpecified extends HubbleError {}
 
+export class UserNotExist extends HubbleError {}
+
 class StateTreeExceptions extends HubbleError {}
 
 export class SenderNotExist extends StateTreeExceptions {}

--- a/ts/factory.ts
+++ b/ts/factory.ts
@@ -28,6 +28,9 @@ export class User {
     get pubkey() {
         return this.blsSigner.pubkey;
     }
+    toString() {
+        return `<User stateID: ${this.stateID}  pubkeyID: ${this.pubkeyID}>`;
+    }
 }
 
 interface GroupOptions {
@@ -60,6 +63,7 @@ export class Group {
     constructor(private users: User[], private stateProvider: StateProvider) {}
     public connect(provider: StateProvider) {
         this.stateProvider = provider;
+        return this;
     }
     get size() {
         return this.users.length;
@@ -98,7 +102,7 @@ export class Group {
                 initialBalance,
                 nonce
             );
-            this.stateProvider.createState(i, state);
+            this.stateProvider.createState(user.stateID, state);
         }
     }
 }

--- a/ts/factory.ts
+++ b/ts/factory.ts
@@ -90,7 +90,7 @@ export class Group {
     }
     public createStates(options?: createStateOptions) {
         const initialBalance = options?.initialBalance || USDT.castInt(1000.0);
-        const tokenID = options?.tokenID || 1;
+        const tokenID = options?.tokenID === undefined ? 5678 : options.tokenID;
         const zeroNonce = options?.zeroNonce || false;
         const arbitraryInitialNonce = 9;
         for (let i = 0; i < this.users.length; i++) {

--- a/ts/factory.ts
+++ b/ts/factory.ts
@@ -174,9 +174,10 @@ export function txCreate2TransferFactory(
 export function txMassMigrationFactory(
     group: Group,
     spokeID = 0
-): { txs: TxMassMigration[]; signature: solG1 } {
+): { txs: TxMassMigration[]; signature: solG1; senders: User[] } {
     const txs: TxMassMigration[] = [];
     const signatures = [];
+    const senders = [];
     for (const sender of group.userIterator()) {
         const senderState = group.getState(sender);
         const amount = senderState.balance.div(10);
@@ -191,7 +192,8 @@ export function txMassMigrationFactory(
         );
         txs.push(tx);
         signatures.push(sender.sign(tx));
+        senders.push(sender);
     }
     const signature = aggregate(signatures).sol;
-    return { txs, signature };
+    return { txs, signature, senders };
 }

--- a/ts/factory.ts
+++ b/ts/factory.ts
@@ -99,6 +99,13 @@ export class Group {
     public getState(user: User) {
         return this.stateProvider.getState(user.stateID).state;
     }
+    public getPubkeys() {
+        return this.users.map(user => user.pubkey);
+    }
+    public getPubkeyIDs() {
+        return this.users.map(user => user.pubkeyID);
+    }
+
     public syncState(): State[] {
         const states: State[] = [];
         for (const user of this.users) {
@@ -163,16 +170,15 @@ export function txCreate2TransferFactory(
 ): { txs: TxCreate2Transfer[]; signature: solG1 } {
     const txs: TxCreate2Transfer[] = [];
     const signatures = [];
-    const n = Math.min(registered.size, unregistered.size);
-    for (let i = 0; i < n; i++) {
+    if (registered.size != unregistered.size)
+        throw new Error("This factory supports same number of users only");
+    for (let i = 0; i < registered.size; i++) {
         const sender = registered.getUser(i);
         const reciver = unregistered.getUser(i);
         const senderState = registered.getState(sender);
         const amount = senderState.balance.div(10);
         const fee = amount.div(10);
 
-        // uses states for sender
-        // and newStates for receiver as they are not created yet
         const tx = new TxCreate2Transfer(
             sender.stateID,
             reciver.stateID,

--- a/ts/state.ts
+++ b/ts/state.ts
@@ -11,6 +11,10 @@ export class State {
         return new State(pubkeyID, tokenID, BigNumber.from(balance), nonce);
     }
 
+    public clone() {
+        return new State(this.pubkeyID, this.tokenID, this.balance, this.nonce);
+    }
+
     constructor(
         public pubkeyID: number,
         public tokenID: number,

--- a/ts/state.ts
+++ b/ts/state.ts
@@ -1,11 +1,7 @@
-import { Domain, solG2 } from "./mcl";
-import { SignableTx } from "./tx";
 import { BigNumber, BigNumberish, ethers } from "ethers";
 import { solidityPack } from "ethers/lib/utils";
-import { BlsSignerInterface, NullBlsSinger, BlsSigner } from "./blsSigner";
 
 export class State {
-    public signer: BlsSignerInterface = new NullBlsSinger();
     public static new(
         pubkeyID: number,
         tokenID: number,
@@ -15,44 +11,12 @@ export class State {
         return new State(pubkeyID, tokenID, BigNumber.from(balance), nonce);
     }
 
-    // TODO add optional params for pubkey and stateID
-    public clone() {
-        const state = new State(
-            this.pubkeyID,
-            this.tokenID,
-            this.balance,
-            this.nonce
-        );
-        state.setStateID(this.stateID);
-        state.signer = this.signer;
-        return state;
-    }
-
-    public stateID = -1;
     constructor(
         public pubkeyID: number,
         public tokenID: number,
         public balance: BigNumber,
         public nonce: number
     ) {}
-
-    public newKeyPair(domain: Domain): State {
-        this.signer = BlsSigner.new(domain);
-        return this;
-    }
-
-    public sign(tx: SignableTx) {
-        return this.signer.sign(tx.message());
-    }
-
-    public setStateID(stateID: number): State {
-        this.stateID = stateID;
-        return this;
-    }
-
-    public getPubkey(): solG2 {
-        return this.signer.pubkey;
-    }
 
     public encode(): string {
         return solidityPack(

--- a/ts/stateTree.ts
+++ b/ts/stateTree.ts
@@ -12,6 +12,25 @@ import {
     WrongTokenID
 } from "./exceptions";
 
+export interface StateProvider {
+    getState(stateID: number): SolStateMerkleProof;
+    createState(stateID: number, state: State): void;
+}
+
+class NullProvider implements StateProvider {
+    getState(stateID: number): SolStateMerkleProof {
+        throw new Error(
+            "This is a NullProvider, please connect to a real provider"
+        );
+    }
+    createState(stateID: number, state: State) {
+        throw new Error(
+            "This is a NullProvider, please connect to a real provider"
+        );
+    }
+}
+export const nullProvider = new NullProvider();
+
 interface SolStateMerkleProof {
     state: State;
     witness: string[];
@@ -60,7 +79,7 @@ function processNoRaise(
     return { proofs, safe };
 }
 
-export class StateTree {
+export class StateTree implements StateProvider {
     public static new(stateDepth: number) {
         return new StateTree(stateDepth);
     }
@@ -104,15 +123,14 @@ export class StateTree {
         return this.stateTree.depth;
     }
 
-    public createState(state: State) {
-        const stateID = state.stateID;
+    public createState(stateID: number, state: State) {
         if (this.states[stateID])
             throw new StateAlreadyExist(`stateID: ${stateID}`);
         this.updateState(stateID, state);
     }
-    public createStateBulk(states: State[]) {
-        for (const state of states) {
-            this.createState(state);
+    public createStateBulk(firstStateID: number, states: State[]) {
+        for (const [i, state] of states.entries()) {
+            this.createState(firstStateID + i, state);
         }
     }
 


### PR DESCRIPTION
### What's wrong

The current way that State signs stuff and holds balance lets us shoot ourselves in the foot.

- Key is lost when a state is created or cloned
- Balance is outdated
- Mock state has the source of truth of keys and the state tree has the source of truth of balance

### How we are fixing it

We create a User class that knows only their stateID and pubkeyID and they sign stuff.

State only holds balances and the state tree has the single source of truth of balances.

We also created a Group class to handle a group of users gracefully.
