### PR TITLE
Fix batch update

### DIFF
--- a/contracts/AccountTree.sol
+++ b/contracts/AccountTree.sol
@@ -82,7 +82,7 @@ contract AccountTree {
         bytes32 leaf = leafs[0];
 
         // Ascend to the root
-        uint256 path = leafIndexRight;
+        uint256 path = leafIndexRight / BATCH_SIZE;
         bool subtreeSet = false;
         for (uint256 i = 0; i < DEPTH - BATCH_DEPTH; i++) {
             if (path & 1 == 1) {
@@ -98,8 +98,8 @@ contract AccountTree {
         }
         rootRight = leaf;
         root = keccak256(abi.encode(rootLeft, rootRight));
-        leafIndexRight += 1;
-        return leafIndexRight - 1;
+        leafIndexRight += BATCH_SIZE;
+        return leafIndexRight - BATCH_SIZE;
     }
 
     function _checkInclusion(

--- a/test/accountTree.test.ts
+++ b/test/accountTree.test.ts
@@ -42,6 +42,8 @@ describe("Account Tree", async () => {
     it("update with single leaf", async function() {
         for (let i = 0; i < 33; i++) {
             const leaf = randHex(32);
+            const leafIndexLeft = Number(await accountTree.leafIndexLeft());
+            assert.equal(leafIndexLeft, i);
             treeLeft.updateSingle(i, leaf);
             await accountTree.updateSingle(leaf);
             assert.equal(treeLeft.root, await accountTree.rootLeft());

--- a/test/accountTree.test.ts
+++ b/test/accountTree.test.ts
@@ -53,6 +53,8 @@ describe("Account Tree", async () => {
         const batchSize = 1 << BATCH_DEPTH;
         for (let k = 0; k < 4; k++) {
             const leafs = randomLeaves(batchSize);
+            const leafIndexRight = Number(await accountTree.leafIndexRight());
+            assert.equal(leafIndexRight, batchSize * k);
             treeRight.updateBatch(batchSize * k, leafs);
             await accountTree.updateBatch(leafs);
             assert.equal(treeRight.root, await accountTree.rootRight());


### PR DESCRIPTION
### What's wrong

The leafIndexRight should increase by a batch size on every batch update, but it currently only increase by 1. That's why the `PubkeyRegistered` starts to emit the incorrect pubkeyIDs since the second batch update.
