### PR TITLE
Revamp trees

### DIFF
--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -47,7 +47,7 @@ describe("Registry", async () => {
         const root = hasher.hash2(treeLeft.root, treeRight.root);
         assert.equal(root, await registry.root());
     });
-    it.skip("batch update", async function() {
+    it("batch update", async function() {
         const batchSize = 1 << BATCH_DEPTH;
         for (let k = 0; k < 4; k++) {
             let leafs = [];

--- a/ts/accountTree.ts
+++ b/ts/accountTree.ts
@@ -1,15 +1,17 @@
 import { Tree } from "./tree";
 import { BlsAccountRegistry } from "../types/ethers-contracts/BlsAccountRegistry";
 import { ethers } from "ethers";
-import { assert } from "chai";
+import { solG2 } from "./mcl";
+import { RegistrationFail } from "./exceptions";
 
+// Tree is 32 level depth, the index is still smaller than Number.MAX_SAFE_INTEGER
 export class AccountRegistry {
     treeLeft: Tree;
     treeRight: Tree;
-    // TODO: must be big int
     leftIndex: number = 0;
-    rigthIndex: number = 0;
+    rightIndex: number = 0;
     setSize: number;
+    batchSize: number;
 
     public static async new(
         registry: BlsAccountRegistry
@@ -25,26 +27,70 @@ export class AccountRegistry {
     ) {
         this.treeLeft = Tree.new(depth);
         this.treeRight = Tree.new(depth);
-        this.setSize = 1 << depth;
+        this.setSize = 2 ** depth;
+        this.batchSize = 2 ** batchDepth;
     }
 
-    public async register(pubkey: string[]): Promise<number> {
-        const pubkeyID = (await this.registry.leafIndexLeft()).toNumber();
-        await (await this.registry.register(pubkey)).wait();
+    public async register(pubkey: solG2): Promise<number> {
+        const pubkeyID = await this.syncLeftIndex();
+        await this.registry.register(pubkey);
         const leaf = this.pubkeyToLeaf(pubkey);
         this.treeLeft.updateSingle(pubkeyID, leaf);
-        const _witness = this.witness(pubkeyID);
-        assert.isTrue(
-            await this.registry.exists(pubkeyID, pubkey, _witness.slice(0, 31))
-        );
+        const exist = await this.checkExistence(pubkeyID, pubkey);
+        if (!exist) throw new RegistrationFail(`PubkeyID ${pubkeyID}`);
+        await this.syncLeftIndex();
         return pubkeyID;
+    }
+    public async registerBatch(pubkeys: solG2[]): Promise<number> {
+        const length = pubkeys.length;
+        if (length != this.batchSize)
+            throw new Error(
+                `Expect batch of ${this.batchSize} pubkeys, got ${length}`
+            );
+        const rigthIndex = await this.syncRightIndex();
+        await this.registry.registerBatch(pubkeys);
+        const leaves = pubkeys.map(key => this.pubkeyToLeaf(key));
+        this.treeRight.updateBatch(rigthIndex, leaves);
+        const firstPubkeyID = rigthIndex + this.setSize;
+        const lastPubkeyID = firstPubkeyID + length - 1;
+        const exist = await this.checkExistence(
+            lastPubkeyID,
+            pubkeys[length - 1]
+        );
+        if (!exist) throw new RegistrationFail(`LastID ${lastPubkeyID}`);
+        await this.syncRightIndex();
+        return firstPubkeyID;
+    }
+
+    public async checkExistence(
+        pubkeyID: number,
+        pubkey: solG2
+    ): Promise<boolean> {
+        // To do merkle check on chain, we only need 31 hashes in the witness
+        // The 32 hash is the root of the left or right tree, which account tree will get it for us.
+        const _witness = this.witness(pubkeyID).slice(0, 31);
+        return await this.registry.exists(pubkeyID, pubkey, _witness);
+    }
+    private async syncLeftIndex(): Promise<number> {
+        this.leftIndex = (await this.registry.leafIndexLeft()).toNumber();
+        return this.leftIndex;
+    }
+    private async syncRightIndex(): Promise<number> {
+        this.rightIndex = (await this.registry.leafIndexRight()).toNumber();
+        return this.rightIndex;
     }
 
     public witness(pubkeyID: number): string[] {
-        // TODO: from right
-        const witness = this.treeLeft.witness(pubkeyID).nodes;
-        witness.push(this.treeRight.root);
-        return witness;
+        if (pubkeyID < this.treeLeft.setSize) {
+            const witness = this.treeLeft.witness(pubkeyID).nodes;
+            witness.push(this.treeRight.root);
+            return witness;
+        } else {
+            const rightTreeID = pubkeyID - this.setSize;
+            const witness = this.treeRight.witness(rightTreeID).nodes;
+            witness.push(this.treeLeft.root);
+            return witness;
+        }
     }
 
     public root() {
@@ -52,7 +98,7 @@ export class AccountRegistry {
         return hasher.hash2(this.treeLeft.root, this.treeRight.root);
     }
 
-    public pubkeyToLeaf(uncompressed: string[]) {
+    public pubkeyToLeaf(uncompressed: solG2) {
         const leaf = ethers.utils.solidityKeccak256(
             ["uint256", "uint256", "uint256", "uint256"],
             uncompressed

--- a/ts/accountTree.ts
+++ b/ts/accountTree.ts
@@ -2,7 +2,7 @@ import { Tree } from "./tree";
 import { BlsAccountRegistry } from "../types/ethers-contracts/BlsAccountRegistry";
 import { ethers } from "ethers";
 import { solG2 } from "./mcl";
-import { RegistrationFail } from "./exceptions";
+import { RegistrationFail, WrongBatchSize } from "./exceptions";
 
 // Tree is 32 level depth, the index is still smaller than Number.MAX_SAFE_INTEGER
 export class AccountRegistry {
@@ -44,8 +44,8 @@ export class AccountRegistry {
     public async registerBatch(pubkeys: solG2[]): Promise<number> {
         const length = pubkeys.length;
         if (length != this.batchSize)
-            throw new Error(
-                `Expect batch of ${this.batchSize} pubkeys, got ${length}`
+            throw new WrongBatchSize(
+                `Expect ${this.batchSize} pubkeys, got ${length}`
             );
         const rigthIndex = await this.syncRightIndex();
         await this.registry.registerBatch(pubkeys);

--- a/ts/exceptions.ts
+++ b/ts/exceptions.ts
@@ -10,6 +10,12 @@ export class UserNotExist extends HubbleError {}
 
 export class TreeException extends HubbleError {}
 
+class AccountTreeException extends HubbleError {}
+
+class StateTreeExceptions extends HubbleError {}
+
+// TreeException
+
 export class ExceedTreeSize extends TreeException {}
 
 export class BadMergeAlignment extends TreeException {}
@@ -20,7 +26,12 @@ export class MismatchLength extends TreeException {}
 
 export class MismatchHash extends TreeException {}
 
-class StateTreeExceptions extends HubbleError {}
+export class NegativeIndex extends TreeException {}
+
+// AccountTreeException
+export class RegistrationFail extends AccountTreeException {}
+
+// StateTreeExceptions
 
 export class ExceedStateTreeSize extends StateTreeExceptions {}
 

--- a/ts/exceptions.ts
+++ b/ts/exceptions.ts
@@ -8,9 +8,21 @@ export class GenesisNotSpecified extends HubbleError {}
 
 export class UserNotExist extends HubbleError {}
 
+export class TreeException extends HubbleError {}
+
+export class ExceedTreeSize extends TreeException {}
+
+export class BadMergeAlignment extends TreeException {}
+
+export class EmptyArray extends TreeException {}
+
+export class MismatchLength extends TreeException {}
+
+export class MismatchHash extends TreeException {}
+
 class StateTreeExceptions extends HubbleError {}
 
-export class ExceedTreeSize extends StateTreeExceptions {}
+export class ExceedStateTreeSize extends StateTreeExceptions {}
 
 export class SenderNotExist extends StateTreeExceptions {}
 

--- a/ts/exceptions.ts
+++ b/ts/exceptions.ts
@@ -31,6 +31,8 @@ export class NegativeIndex extends TreeException {}
 // AccountTreeException
 export class RegistrationFail extends AccountTreeException {}
 
+export class WrongBatchSize extends AccountTreeException {}
+
 // StateTreeExceptions
 
 export class ExceedStateTreeSize extends StateTreeExceptions {}

--- a/ts/stateTree.ts
+++ b/ts/stateTree.ts
@@ -5,7 +5,7 @@ import { BigNumber, constants } from "ethers";
 import { ZERO_BYTES32 } from "./constants";
 import { minTreeDepth, sum } from "./utils";
 import {
-    ExceedTreeSize,
+    ExceedStateTreeSize,
     InsufficientFund,
     ReceiverNotExist,
     SenderNotExist,
@@ -100,7 +100,7 @@ export class StateTree implements StateProvider {
     }
     private checkSize(stateID: number) {
         if (stateID >= this.stateTree.setSize)
-            throw new ExceedTreeSize(
+            throw new ExceedStateTreeSize(
                 `Want stateID ${stateID} but the tree has only ${this.stateTree.setSize} leaves`
             );
     }

--- a/ts/tree/tree.ts
+++ b/ts/tree/tree.ts
@@ -5,7 +5,8 @@ import {
     EmptyArray,
     ExceedTreeSize,
     MismatchHash,
-    MismatchLength
+    MismatchLength,
+    NegativeIndex
 } from "../exceptions";
 import { Hasher, Node } from "./hasher";
 
@@ -132,6 +133,8 @@ export class Tree {
             throw new ExceedTreeSize(
                 `Leaf index ${index}; tree size ${this.setSize}`
             );
+        // Probably an overflow if this error is hit
+        if (index < 0) throw new NegativeIndex(`${index}`);
     }
 
     // insertSingle updates tree with a single raw data at given index
@@ -160,12 +163,12 @@ export class Tree {
     }
 
     // updateBatch given multiple sequencial data updates tree ascending from an offset
-    public updateBatch(offset: number, data: Array<Node>) {
-        const len = data.length;
+    public updateBatch(offset: number, leaves: Array<Node>) {
+        const len = leaves.length;
         if (len == 0) throw new EmptyArray();
         this.checkSetSize(len + offset);
         for (let i = 0; i < len; i++) {
-            this.tree[this.depth][offset + i] = data[i];
+            this.tree[this.depth][offset + i] = leaves[i];
         }
         this.ascend(offset, len);
     }

--- a/ts/tree/tree.ts
+++ b/ts/tree/tree.ts
@@ -155,7 +155,8 @@ export class Tree {
     public insertBatch(offset: number, data: Array<Data>) {
         const len = data.length;
         if (len == 0) throw new EmptyArray();
-        this.checkSetSize(len + offset);
+        const lastIndex = len + offset - 1;
+        this.checkSetSize(lastIndex);
         for (let i = 0; i < len; i++) {
             this.tree[this.depth][offset + i] = this.hasher.toLeaf(data[i]);
         }
@@ -166,7 +167,8 @@ export class Tree {
     public updateBatch(offset: number, leaves: Array<Node>) {
         const len = leaves.length;
         if (len == 0) throw new EmptyArray();
-        this.checkSetSize(len + offset);
+        const lastIndex = len + offset - 1;
+        this.checkSetSize(lastIndex);
         for (let i = 0; i < len; i++) {
             this.tree[this.depth][offset + i] = leaves[i];
         }


### PR DESCRIPTION
### What's wrong

- AccountTree didn't handle 32 depths well
- Tree fails silently

### How are we fixing it

Instead of wrangling everything in BigNumbers or doing JS integers correctly, we raise explicit exceptions and add failing inputs to the error message stack to speed up dev iteration.

