### PR TITLE
Naive implementation to fix double sender check

### DIFF
--- a/contracts/Create2Transfer.sol
+++ b/contracts/Create2Transfer.sol
@@ -11,22 +11,10 @@ contract Create2Transfer {
     using SafeMath for uint256;
 
     function checkSignature(
-        uint256[2] memory signature,
-        Types.SignatureProofWithReceiver memory proof,
-        bytes32 stateRoot,
-        bytes32 accountRoot,
-        bytes32 domain,
-        bytes memory txs
+        Types.AuthCommon memory common,
+        Types.SignatureProofWithReceiver memory proof
     ) public view returns (Types.Result) {
-        return
-            Authenticity.verifyCreate2Transfer(
-                signature,
-                proof,
-                stateRoot,
-                accountRoot,
-                domain,
-                txs
-            );
+        return Authenticity.verifyCreate2Transfer(common, proof);
     }
 
     /**

--- a/contracts/MassMigrations.sol
+++ b/contracts/MassMigrations.sol
@@ -13,24 +13,11 @@ contract MassMigration {
     using Tx for bytes;
 
     function checkSignature(
-        uint256[2] memory signature,
+        Types.AuthCommon memory common,
         Types.SignatureProof memory proof,
-        bytes32 stateRoot,
-        bytes32 accountRoot,
-        bytes32 domain,
-        uint256 spokeID,
-        bytes memory txs
+        uint256 spokeID
     ) public view returns (Types.Result) {
-        return
-            Authenticity.verifyMassMigration(
-                signature,
-                proof,
-                stateRoot,
-                accountRoot,
-                domain,
-                spokeID,
-                txs
-            );
+        return Authenticity.verifyMassMigration(common, proof, spokeID);
     }
 
     /**

--- a/contracts/Transfer.sol
+++ b/contracts/Transfer.sol
@@ -12,22 +12,10 @@ contract Transfer {
     using Tx for bytes;
 
     function checkSignature(
-        uint256[2] memory signature,
-        Types.SignatureProof memory proof,
-        bytes32 stateRoot,
-        bytes32 accountRoot,
-        bytes32 domain,
-        bytes memory txs
+        Types.AuthCommon memory common,
+        Types.SignatureProof memory proof
     ) public view returns (Types.Result) {
-        return
-            Authenticity.verifyTransfer(
-                signature,
-                proof,
-                stateRoot,
-                accountRoot,
-                domain,
-                txs
-            );
+        return Authenticity.verifyTransfer(common, proof);
     }
 
     /**

--- a/contracts/client/FrontendCreate2Transfer.sol
+++ b/contracts/client/FrontendCreate2Transfer.sol
@@ -196,14 +196,14 @@ contract FrontendCreate2Transfer {
         bytes32 domain,
         bytes memory txs
     ) public view returns (Types.Result) {
-        return
-            Authenticity.verifyCreate2Transfer(
-                signature,
-                proof,
-                stateRoot,
-                accountRoot,
-                domain,
-                txs
-            );
+        Types.AuthCommon memory common = Types.AuthCommon({
+            signature: signature,
+            stateRoot: stateRoot,
+            accountRoot: accountRoot,
+            domain: domain,
+            txs: txs
+        });
+
+        return Authenticity.verifyCreate2Transfer(common, proof);
     }
 }

--- a/contracts/client/FrontendMassMigration.sol
+++ b/contracts/client/FrontendMassMigration.sol
@@ -173,15 +173,13 @@ contract FrontendMassMigration {
         uint256 spokeID,
         bytes memory txs
     ) public view returns (Types.Result) {
-        return
-            Authenticity.verifyMassMigration(
-                signature,
-                proof,
-                stateRoot,
-                accountRoot,
-                domain,
-                spokeID,
-                txs
-            );
+        Types.AuthCommon memory common = Types.AuthCommon({
+            signature: signature,
+            stateRoot: stateRoot,
+            accountRoot: accountRoot,
+            domain: domain,
+            txs: txs
+        });
+        return Authenticity.verifyMassMigration(common, proof, spokeID);
     }
 }

--- a/contracts/client/FrontendTransfer.sol
+++ b/contracts/client/FrontendTransfer.sol
@@ -163,14 +163,13 @@ contract FrontendTransfer {
         bytes32 domain,
         bytes memory txs
     ) public view returns (Types.Result) {
-        return
-            Authenticity.verifyTransfer(
-                signature,
-                proof,
-                stateRoot,
-                accountRoot,
-                domain,
-                txs
-            );
+        Types.AuthCommon memory common = Types.AuthCommon({
+            signature: signature,
+            stateRoot: stateRoot,
+            accountRoot: accountRoot,
+            domain: domain,
+            txs: txs
+        });
+        return Authenticity.verifyTransfer(common, proof);
     }
 }

--- a/contracts/libs/Types.sol
+++ b/contracts/libs/Types.sol
@@ -21,6 +21,14 @@ library Types {
         bytes32[][] pubkeyWitnessesReceiver;
     }
 
+    struct AuthCommon {
+        uint256[2] signature;
+        bytes32 stateRoot;
+        bytes32 accountRoot;
+        bytes32 domain;
+        bytes txs;
+    }
+
     enum Usage { Genesis, Transfer, MassMigration, Create2Transfer, Deposit }
 
     // Batch represents the batch submitted periodically to the ethereum chain

--- a/contracts/rollup/Rollup.sol
+++ b/contracts/rollup/Rollup.sol
@@ -341,15 +341,14 @@ contract RollupCore is BatchManager {
             checkInclusion(batches[batchID].commitmentRoot, target),
             "Rollup: Commitment not present in batch"
         );
-
-        Types.Result result = transfer.checkSignature(
-            target.commitment.body.signature,
-            signatureProof,
-            target.commitment.stateRoot,
-            target.commitment.body.accountRoot,
-            appID,
-            target.commitment.body.txs
-        );
+        Types.AuthCommon memory common = Types.AuthCommon({
+            signature: target.commitment.body.signature,
+            stateRoot: target.commitment.stateRoot,
+            accountRoot: target.commitment.body.accountRoot,
+            domain: appID,
+            txs: target.commitment.body.txs
+        });
+        Types.Result result = transfer.checkSignature(common, signatureProof);
 
         if (result != Types.Result.Ok) startRollingBack(batchID);
     }
@@ -363,15 +362,18 @@ contract RollupCore is BatchManager {
             checkInclusion(batches[batchID].commitmentRoot, target),
             "Commitment not present in batch"
         );
+        Types.AuthCommon memory common = Types.AuthCommon({
+            signature: target.commitment.body.signature,
+            stateRoot: target.commitment.stateRoot,
+            accountRoot: target.commitment.body.accountRoot,
+            domain: appID,
+            txs: target.commitment.body.txs
+        });
 
         Types.Result result = massMigration.checkSignature(
-            target.commitment.body.signature,
+            common,
             signatureProof,
-            target.commitment.stateRoot,
-            target.commitment.body.accountRoot,
-            appID,
-            target.commitment.body.spokeID,
-            target.commitment.body.txs
+            target.commitment.body.spokeID
         );
 
         if (result != Types.Result.Ok) startRollingBack(batchID);
@@ -386,14 +388,17 @@ contract RollupCore is BatchManager {
             checkInclusion(batches[batchID].commitmentRoot, target),
             "Rollup: Commitment not present in batch"
         );
+        Types.AuthCommon memory common = Types.AuthCommon({
+            signature: target.commitment.body.signature,
+            stateRoot: target.commitment.stateRoot,
+            accountRoot: target.commitment.body.accountRoot,
+            domain: appID,
+            txs: target.commitment.body.txs
+        });
 
         Types.Result result = create2Transfer.checkSignature(
-            target.commitment.body.signature,
-            signatureProof,
-            target.commitment.stateRoot,
-            target.commitment.body.accountRoot,
-            appID,
-            target.commitment.body.txs
+            common,
+            signatureProof
         );
 
         if (result != Types.Result.Ok) startRollingBack(batchID);

--- a/contracts/test/TestCreate2Transfer.sol
+++ b/contracts/test/TestCreate2Transfer.sol
@@ -16,14 +16,14 @@ contract TestCreate2Transfer is Create2Transfer {
         bytes memory txs
     ) public returns (uint256, Types.Result) {
         uint256 operationCost = gasleft();
-        Types.Result err = checkSignature(
-            signature,
-            proof,
-            stateRoot,
-            accountRoot,
-            domain,
-            txs
-        );
+        Types.AuthCommon memory common = Types.AuthCommon({
+            signature: signature,
+            stateRoot: stateRoot,
+            accountRoot: accountRoot,
+            domain: domain,
+            txs: txs
+        });
+        Types.Result err = checkSignature(common, proof);
         return (operationCost - gasleft(), err);
     }
 

--- a/contracts/test/TestMassMigration.sol
+++ b/contracts/test/TestMassMigration.sol
@@ -15,15 +15,14 @@ contract TestMassMigration is MassMigration {
         bytes memory txs
     ) public view returns (uint256 gasCost, Types.Result result) {
         gasCost = gasleft();
-        result = checkSignature(
-            signature,
-            proof,
-            stateRoot,
-            accountRoot,
-            domain,
-            spokeID,
-            txs
-        );
+        Types.AuthCommon memory common = Types.AuthCommon({
+            signature: signature,
+            stateRoot: stateRoot,
+            accountRoot: accountRoot,
+            domain: domain,
+            txs: txs
+        });
+        result = checkSignature(common, proof, spokeID);
         gasCost = gasCost - gasleft();
     }
 

--- a/contracts/test/TestTransfer.sol
+++ b/contracts/test/TestTransfer.sol
@@ -16,14 +16,14 @@ contract TestTransfer is Transfer {
         bytes memory txs
     ) public returns (uint256, Types.Result) {
         uint256 operationCost = gasleft();
-        Types.Result result = checkSignature(
-            signature,
-            proof,
-            stateRoot,
-            accountRoot,
-            domain,
-            txs
-        );
+        Types.AuthCommon memory common = Types.AuthCommon({
+            signature: signature,
+            stateRoot: stateRoot,
+            accountRoot: accountRoot,
+            domain: domain,
+            txs: txs
+        });
+        Types.Result result = checkSignature(common, proof);
         return (operationCost - gasleft(), result);
     }
 

--- a/test/slow/commit.massMigration.test.ts
+++ b/test/slow/commit.massMigration.test.ts
@@ -88,7 +88,7 @@ describe("Rollup Mass Migration", () => {
         assert.equal(result, Result.Ok, `Got ${Result[result]}`);
         console.log("operation gas cost:", gasCost.toString());
     }).timeout(400000);
-    it.only("checks signature: same sender", async function() {
+    it("checks signature: same sender", async function() {
         const smallGroup = users.slice(4);
         let manySameSenderGroup = smallGroup;
         for (let i = 0; i < 7; i++) {
@@ -131,7 +131,7 @@ describe("Rollup Mass Migration", () => {
         );
         assert.equal(result, Result.Ok, `Got ${Result[result]}`);
         console.log("operation gas cost:", gasCost.toString());
-    }).timeout(400000);
+    }).timeout(800000);
 
     it("checks state transitions", async function() {
         const { txs } = txMassMigrationFactory(users, spokeID);

--- a/test/slow/commit.transfer.test.ts
+++ b/test/slow/commit.transfer.test.ts
@@ -111,9 +111,6 @@ describe("Rollup Transfer Commitment", () => {
             fewSenderGroup,
             COMMIT_SIZE
         );
-        for (const tx of txs) {
-            console.log(`${tx}`);
-        }
         const pubkeys = senders.map(sender => sender.pubkey);
         const pubkeyWitnesses = senders.map(sender =>
             registry.witness(sender.pubkeyID)

--- a/ts/factory.ts
+++ b/ts/factory.ts
@@ -219,6 +219,7 @@ export function txCreate2TransferFactory(
         const nonce = seenNonce[sender.stateID]
             ? seenNonce[sender.stateID] + 1
             : senderState.nonce;
+        seenNonce[sender.stateID] = nonce;
 
         const tx = new TxCreate2Transfer(
             sender.stateID,
@@ -252,6 +253,7 @@ export function txMassMigrationFactory(
         const nonce = seenNonce[sender.stateID]
             ? seenNonce[sender.stateID] + 1
             : senderState.nonce;
+        seenNonce[sender.stateID] = nonce;
 
         const tx = new TxMassMigration(
             sender.stateID,

--- a/ts/factory.ts
+++ b/ts/factory.ts
@@ -205,9 +205,10 @@ export function txTransferFactory(
 export function txCreate2TransferFactory(
     registered: Group,
     unregistered: Group
-): { txs: TxCreate2Transfer[]; signature: solG1 } {
+): { txs: TxCreate2Transfer[]; signature: solG1; senders: User[] } {
     const txs: TxCreate2Transfer[] = [];
     const signatures = [];
+    const senders = [];
     const seenNonce: { [stateID: number]: number } = {};
     const n = Math.max(registered.size, unregistered.size);
     for (let i = 0; i < n; i++) {
@@ -233,9 +234,10 @@ export function txCreate2TransferFactory(
         );
         txs.push(tx);
         signatures.push(sender.sign(tx));
+        senders.push(sender);
     }
     const signature = aggregate(signatures).sol;
-    return { txs, signature };
+    return { txs, signature, senders };
 }
 
 export function txMassMigrationFactory(

--- a/ts/factory.ts
+++ b/ts/factory.ts
@@ -174,18 +174,23 @@ export function txTransferFactory(
     const txs: TxTransfer[] = [];
     const signatures = [];
     const senders = [];
+    const seenNonce: { [stateID: number]: number } = {};
     for (let i = 0; i < n; i++) {
         const sender = group.getUser(i % group.size);
         const receiver = group.getUser((i + 5) % group.size);
         const senderState = group.getState(sender);
         const amount = USDT.castBigNumber(senderState.balance.div(10));
         const fee = USDT.castBigNumber(amount.div(10));
+        const nonce = seenNonce[sender.stateID]
+            ? seenNonce[sender.stateID] + 1
+            : senderState.nonce;
+        seenNonce[sender.stateID] = nonce;
         const tx = new TxTransfer(
             sender.stateID,
             receiver.stateID,
             amount,
             fee,
-            senderState.nonce,
+            nonce,
             USDT
         );
         txs.push(tx);

--- a/ts/tx.ts
+++ b/ts/tx.ts
@@ -224,6 +224,9 @@ export class TxMassMigration implements SignableTx {
         ]);
         return hexlify(concated);
     }
+    public toString(): string {
+        return `<Migration ${this.fromIndex}->${this.spokeID} $${this.amount}  fee ${this.fee}  nonce ${this.nonce}>`;
+    }
 }
 
 export class TxCreate2Transfer implements SignableTx {
@@ -334,5 +337,8 @@ export class TxCreate2Transfer implements SignableTx {
             this.decimal.encodeInt(this.fee)
         ]);
         return hexlify(concated);
+    }
+    public toString(): string {
+        return `<Create2Transfer ${this.fromIndex}->${this.toIndex} (${this.toPubkeyID}) $${this.amount}  fee ${this.fee}  nonce ${this.nonce}>`;
     }
 }

--- a/ts/tx.ts
+++ b/ts/tx.ts
@@ -143,6 +143,9 @@ export class TxTransfer implements SignableTx {
         ]);
         return hexlify(concated);
     }
+    public toString(): string {
+        return `<Transfer ${this.fromIndex}->${this.toIndex} $${this.amount}  fee ${this.fee}  nonce ${this.nonce}>`;
+    }
 }
 
 export class TxMassMigration implements SignableTx {


### PR DESCRIPTION
Fix #382 

- We first reproduce the bug
- Then we see the gas cost increase of the naive approach

### Signature check Gas Cost

### This PR

- Transfer
  - senders all different
    - operation gas cost: 4664005
    - transaction gas cost: 6377081
  - some same senders
    - operation gas cost: 4798157
- Mass Migration
  - senders all different. operation gas cost: 4614020
  - some same senders: operation gas cost: 4550813
- Create2Transfer
  - senders all different
    - operation gas cost: 5406666
    - transaction gas cost: 8009615
  - some same senders
    - operation gas cost: 5438038

#### Master (senders all different)

- Transfer
  - operation gas cost: 4610066
  - transaction gas cost: 6323012
- Mass Migration
  - operation gas cost: 4603308
- Create2Transfer
  - operation gas cost: 5338076
  - transaction gas cost: 7941113



