### PR TITLE
Add Hubble class and hubble repl

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "repl": "ts-node ./scripts/repl.ts",
     "test": "hardhat test",
     "solhint": "solhint \"contracts/**/*.sol\" -f unix",
     "lint": "prettier --check \"**/*.{sol,ts,js}\"",

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -2,19 +2,17 @@ import { ethers } from "ethers";
 import { allContracts } from "../ts/allContractsInterfaces";
 import { deployAll } from "../ts/deploy";
 import { DeploymentParameters } from "../ts/interfaces";
-import { BlsAccountRegistry } from "../types/ethers-contracts/BlsAccountRegistry";
 import fs from "fs";
 import { PRODUCTION_PARAMS } from "../ts/constants";
 import { StateTree } from "../ts/stateTree";
 
 const argv = require("minimist")(process.argv.slice(2), {
-    string: ["url", "root", "pubkeys"]
+    string: ["url", "root"]
 });
 /*
     Note separate pubkeys with commas
     > npm run deploy -- --url http://localhost:8545 \
-    --root 0x309976060df37ed6961ebd53027fe0c45d3cbbbdfc30a5039e86b2a7aa7fed6e \
-    --pubkeys 06642b1af0ec2f7369126b3e45aaf11a050a26e2111150b319c4ca2f4a8d48c62442e01b651ce469632972f06c4d5d092da2cde3d42c0ead5ebeed8646d72b3f1f09c41c70cbdd8779920b4a3b15e6c7c518c5fdb93fdaed7a49c59b1f4d1e210aafa7a17239c9df9053ca4e71f10fb9f7b0f219e12e300676a756463253c287,2a7575b1bddf2c2b25f976788baae059ea410f589f0c244e1554d6f6f5398b6a1b997670d19c26c33ad1c61e21bd2742565518e0deafb105e7718de983bf757a0770cb4889aabb6f4897534f4770fce4b76f39b2cc8ed63b22e55ebf7e87a96001bbabd11ca55585bc0c016ad058a69c682cbe102a4b91f6084c71c857509dac
+    --root 0x309976060df37ed6961ebd53027fe0c45d3cbbbdfc30a5039e86b2a7aa7fed6e
 */
 
 function getDefaultGenesisRoot(parameters: DeploymentParameters) {
@@ -44,30 +42,6 @@ async function main() {
     console.log("Writing genesis.json");
     fs.writeFileSync("genesis.json", JSON.stringify(configs, null, 4));
     console.log("Successsfully deployed", configs);
-
-    if (argv.pubkeys) {
-        const pubkeys = argv.pubkeys.split(",");
-        await registerPublicKeys(contracts.blsAccountRegistry, pubkeys);
-    }
-}
-
-async function registerPublicKeys(
-    blsAccountRegistry: BlsAccountRegistry,
-    pubkeys: string[]
-) {
-    console.log(`Registering ${pubkeys.length} public keys`);
-    for (const pubkeyRaw of pubkeys) {
-        const parsedPubkey = [
-            pubkeyRaw.slice(64, 128),
-            pubkeyRaw.slice(0, 64),
-            pubkeyRaw.slice(192, 256),
-            pubkeyRaw.slice(128, 192)
-        ].map(_ => "0x" + _);
-        console.log("Registering", parsedPubkey);
-        const tx = await blsAccountRegistry.register(parsedPubkey);
-        await tx.wait();
-        console.log("Done registering pubkey", pubkeyRaw.slice(0, 5));
-    }
 }
 
 main();

--- a/scripts/deposit.ts
+++ b/scripts/deposit.ts
@@ -1,96 +1,45 @@
-import { ethers } from "ethers";
 import { toWei } from "../ts/utils";
-import { BlsAccountRegistryFactory } from "../types/ethers-contracts/BlsAccountRegistryFactory";
-import { DepositManagerFactory } from "../types/ethers-contracts/DepositManagerFactory";
-import { ExampleTokenFactory } from "../types/ethers-contracts/ExampleTokenFactory";
-import { BlsAccountRegistry } from "../types/ethers-contracts/BlsAccountRegistry";
-import { TokenRegistryFactory } from "../types/ethers-contracts/TokenRegistryFactory";
-import fs from "fs";
+import { Hubble } from "../ts/hubble";
 
 const argv = require("minimist")(process.argv.slice(2), {
-    string: ["url", "tokenID", "pubkeys", "amount"]
+    string: ["url", "pubkeys", "amount"]
 });
 
 async function main() {
-    const provider = new ethers.providers.JsonRpcProvider(argv.url);
-    const signer = provider.getSigner();
+    const providerUrl = argv.url || "http://localhost:8545";
 
-    // read genesis
-    let buf = fs.readFileSync(`genesis.json`);
-    let genesis = JSON.parse(buf.toString());
-
-    let depositManager = DepositManagerFactory.connect(
-        genesis.addresses["depositManager"],
-        signer
-    );
-
-    let accountRegistry = BlsAccountRegistryFactory.connect(
-        genesis.addresses["blsAccountRegistry"],
-        signer
-    );
-
-    let exampleToken = ExampleTokenFactory.connect(
-        genesis.addresses["exampleToken"],
-        signer
-    );
-
-    let tokenRegistry = TokenRegistryFactory.connect(
-        genesis.addresses["tokenRegistry"],
-        signer
-    );
+    const hubble = Hubble.fromDefault(providerUrl);
 
     let accIDs: number[] = [];
 
     if (argv.pubkeys) {
         const pubkeys = argv.pubkeys.split(",");
-        accIDs = await registerPublicKeys(accountRegistry, pubkeys);
+        accIDs = await hubble.registerPublicKeys(pubkeys);
     }
+    const { tokenRegistry, exampleToken, depositManager } = hubble.contracts;
 
+    const tokenID = 0;
     // match token address with tokenRegistry
-    let tokenAddress = await tokenRegistry.callStatic.safeGetAddress(
-        argv.tokenID
-    );
+    let tokenAddress = await tokenRegistry.callStatic.safeGetAddress(tokenID);
 
     if (exampleToken.address != tokenAddress) {
         throw "error token address does not match";
     }
 
     // approve depositmanager for amount
-    let amount = toWei(argv.amount);
+    const amount = parseInt(argv.amount);
+    const totalAmount = accIDs.length * amount;
     let approveTx = await exampleToken.approve(
-        genesis.addresses["depositManager"],
-        toWei(argv.amount)
+        depositManager.address,
+        toWei(totalAmount.toString())
     );
 
     console.log("token approved", approveTx.hash.toString());
 
     // make deposit
     for (const accID of accIDs) {
-        await depositManager.depositFor(accID, amount, argv.tokenID);
+        await depositManager.depositFor(accID, amount, tokenID);
     }
-}
-
-async function registerPublicKeys(
-    blsAccountRegistry: BlsAccountRegistry,
-    pubkeys: string[]
-) {
-    let accountIDs: number[] = [];
-    console.log(`Registering ${pubkeys.length} public keys`);
-    for (const pubkeyRaw of pubkeys) {
-        const parsedPubkey = [
-            pubkeyRaw.slice(64, 128),
-            pubkeyRaw.slice(0, 64),
-            pubkeyRaw.slice(192, 256),
-            pubkeyRaw.slice(128, 192)
-        ].map(_ => "0x" + _);
-        console.log("Registering", parsedPubkey);
-        let accID = await blsAccountRegistry.callStatic.register(parsedPubkey);
-        const tx = await blsAccountRegistry.register(parsedPubkey);
-        await tx.wait();
-        accountIDs.push(accID.toNumber());
-        console.log("Done registering pubkey", pubkeyRaw.slice(0, 5), accID);
-    }
-    return accountIDs;
 }
 
 main()

--- a/scripts/deposit.ts
+++ b/scripts/deposit.ts
@@ -1,10 +1,15 @@
-import { toWei } from "../ts/utils";
 import { Hubble } from "../ts/hubble";
 
 const argv = require("minimist")(process.argv.slice(2), {
-    string: ["url", "pubkeys", "amount"]
+    string: ["url", "tokenID", "pubkeys", "amount"]
 });
 
+/**
+npm run deposit -- \
+--tokenID 0 \
+--amount 5 \
+--pubkeys 06642b1af0ec2f7369126b3e45aaf11a050a26e2111150b319c4ca2f4a8d48c62442e01b651ce469632972f06c4d5d092da2cde3d42c0ead5ebeed8646d72b3f1f09c41c70cbdd8779920b4a3b15e6c7c518c5fdb93fdaed7a49c59b1f4d1e210aafa7a17239c9df9053ca4e71f10fb9f7b0f219e12e300676a756463253c287,2a7575b1bddf2c2b25f976788baae059ea410f589f0c244e1554d6f6f5398b6a1b997670d19c26c33ad1c61e21bd2742565518e0deafb105e7718de983bf757a0770cb4889aabb6f4897534f4770fce4b76f39b2cc8ed63b22e55ebf7e87a96001bbabd11ca55585bc0c016ad058a69c682cbe102a4b91f6084c71c857509dac
+ */
 async function main() {
     const providerUrl = argv.url || "http://localhost:8545";
 
@@ -16,30 +21,9 @@ async function main() {
         const pubkeys = argv.pubkeys.split(",");
         accIDs = await hubble.registerPublicKeys(pubkeys);
     }
-    const { tokenRegistry, exampleToken, depositManager } = hubble.contracts;
-
-    const tokenID = 0;
-    // match token address with tokenRegistry
-    let tokenAddress = await tokenRegistry.callStatic.safeGetAddress(tokenID);
-
-    if (exampleToken.address != tokenAddress) {
-        throw "error token address does not match";
-    }
-
-    // approve depositmanager for amount
+    const tokenID = parseInt(argv.tokenID);
     const amount = parseInt(argv.amount);
-    const totalAmount = accIDs.length * amount;
-    let approveTx = await exampleToken.approve(
-        depositManager.address,
-        toWei(totalAmount.toString())
-    );
-
-    console.log("token approved", approveTx.hash.toString());
-
-    // make deposit
-    for (const accID of accIDs) {
-        await depositManager.depositFor(accID, amount, tokenID);
-    }
+    await hubble.depositFor(accIDs, tokenID, amount);
 }
 
 main()

--- a/scripts/repl.ts
+++ b/scripts/repl.ts
@@ -1,26 +1,9 @@
 import repl from "repl";
 import { Hubble } from "../ts/hubble";
-import fs from "fs";
 import { ethers } from "ethers";
 
-function loadGenesis(path: string) {
-    const genesis = fs.readFileSync(path).toString();
-    const { parameters, addresses } = JSON.parse(genesis);
-    return { parameters, addresses };
-}
-
-async function prepareHubble() {
-    const { parameters, addresses } = loadGenesis("./genesis.json");
-    const provider = new ethers.providers.JsonRpcProvider(
-        "http://localhost:8545"
-    );
-    const signer = provider.getSigner();
-    const hubble = Hubble.fromGenesis(parameters, addresses, signer);
-    return hubble;
-}
-
-async function startRepl() {
-    const hubble = await prepareHubble();
+function startRepl() {
+    const hubble = Hubble.fromDefault();
     const local = repl.start("hubble > ");
     local.context.hubble = hubble;
     local.context.ethers = ethers;

--- a/scripts/repl.ts
+++ b/scripts/repl.ts
@@ -1,0 +1,29 @@
+import repl from "repl";
+import { Hubble } from "../ts/hubble";
+import fs from "fs";
+import { ethers } from "ethers";
+
+function loadGenesis(path: string) {
+    const genesis = fs.readFileSync(path).toString();
+    const { parameters, addresses } = JSON.parse(genesis);
+    return { parameters, addresses };
+}
+
+async function prepareHubble() {
+    const { parameters, addresses } = loadGenesis("./genesis.json");
+    const provider = new ethers.providers.JsonRpcProvider(
+        "http://localhost:8545"
+    );
+    const signer = provider.getSigner();
+    const hubble = Hubble.fromGenesis(parameters, addresses, signer);
+    return hubble;
+}
+
+async function startRepl() {
+    const hubble = await prepareHubble();
+    const local = repl.start("hubble > ");
+    local.context.hubble = hubble;
+    local.context.ethers = ethers;
+}
+
+startRepl();

--- a/test/fast/hubble.test.ts
+++ b/test/fast/hubble.test.ts
@@ -1,0 +1,22 @@
+import { ethers } from "hardhat";
+import { allContracts } from "../../ts/allContractsInterfaces";
+import { TESTING_PARAMS, ZERO_BYTES32 } from "../../ts/constants";
+import { deployAll } from "../../ts/deploy";
+import { Hubble } from "../../ts/hubble";
+
+describe("hubble", function() {
+    it("Runs hubble", async function() {
+        const [signer] = await ethers.getSigners();
+        const parameters = {
+            ...TESTING_PARAMS,
+            GENESIS_STATE_ROOT: ZERO_BYTES32
+        };
+        const contracts = await deployAll(signer, parameters);
+        let addresses: { [key: string]: string } = {};
+        Object.keys(contracts).map((contract: string) => {
+            addresses[contract] =
+                contracts[contract as keyof allContracts].address;
+        });
+        const hubble = Hubble.fromGenesis(parameters, addresses, signer);
+    });
+});

--- a/ts/hubble.ts
+++ b/ts/hubble.ts
@@ -1,0 +1,80 @@
+import { allContracts } from "./allContractsInterfaces";
+import { DeploymentParameters } from "./interfaces";
+import fs from "fs";
+import {
+    BlsAccountRegistryFactory,
+    BurnAuctionFactory,
+    Create2TransferFactory,
+    DepositManagerFactory,
+    ExampleTokenFactory,
+    FrontendCreate2TransferFactory,
+    FrontendGenericFactory,
+    FrontendMassMigrationFactory,
+    FrontendTransferFactory,
+    MassMigrationFactory,
+    NameRegistryFactory,
+    ParamManagerFactory,
+    ProofOfBurnFactory,
+    RollupFactory,
+    SpokeRegistryFactory,
+    TokenRegistryFactory,
+    TransferFactory,
+    VaultFactory,
+    WithdrawManagerFactory
+} from "../types/ethers-contracts";
+import { Signer } from "ethers";
+
+function parseGenesis(
+    parameters: DeploymentParameters,
+    addresses: { [key: string]: string },
+    signer: Signer
+): allContracts {
+    const factories = {
+        paramManager: ParamManagerFactory,
+        frontendGeneric: FrontendGenericFactory,
+        frontendTransfer: FrontendTransferFactory,
+        frontendMassMigration: FrontendMassMigrationFactory,
+        frontendCreate2Transfer: FrontendCreate2TransferFactory,
+        nameRegistry: NameRegistryFactory,
+        blsAccountRegistry: BlsAccountRegistryFactory,
+        tokenRegistry: TokenRegistryFactory,
+        transfer: TransferFactory,
+        massMigration: MassMigrationFactory,
+        create2Transfer: Create2TransferFactory,
+        exampleToken: ExampleTokenFactory,
+        spokeRegistry: SpokeRegistryFactory,
+        vault: VaultFactory,
+        depositManager: DepositManagerFactory,
+        rollup: RollupFactory,
+        withdrawManager: WithdrawManagerFactory,
+        chooser: parameters.USE_BURN_AUCTION
+            ? BurnAuctionFactory
+            : ProofOfBurnFactory
+    };
+    const contracts: any = {};
+    for (const [key, factory] of Object.entries(factories)) {
+        const address = addresses[key];
+        if (!address) throw `Bad Genesis: Find no address for ${key} contract`;
+        contracts[key] = factory.connect(address, signer);
+    }
+    return contracts;
+}
+
+export class Hubble {
+    private constructor(
+        public parameters: DeploymentParameters,
+        public contracts: allContracts
+    ) {}
+    static fromGenesis(
+        parameters: DeploymentParameters,
+        addresses: { [key: string]: string },
+        signer: Signer
+    ) {
+        const contracts = parseGenesis(parameters, addresses, signer);
+        return new Hubble(parameters, contracts);
+    }
+
+    show() {
+        console.log(this.contracts);
+    }
+}


### PR DESCRIPTION
### What's wrong

When we want to do something with the deployed contracts. We need to write a lengthy script like #395.

### How are we fixing it

We can create a Hubble class that parses the genesis config and manages all contract instances. So whenever we want to do something with any contract, we access them from the Hubble class. 

We can also extend convenient methods to do insert pubkeys or submit deposits smoothly.

What's best is we can do repl with it. You can run `npm run repl` then it prompts you.

To reproduce this example, we need to run `npm run node` in another terminal and run `npm run deploy`.

The repl instance expose `hubble` and `ethers` instances in the context. So we can access the contract and manipulate the data types with those.

```
hubble > hubble.contracts.exampleToken.approve(hubble.contracts.depositManager.address, ethers.utils.parseEther("100"))
Promise { <pending> }
hubble > hubble.contracts.depositManager.depositFor(0, 100, 0)
Promise { <pending> }
```
