### PR TITLE
fix bls gas

### DIFF
--- a/contracts/libs/BLS.sol
+++ b/contracts/libs/BLS.sol
@@ -124,8 +124,8 @@ library BLS {
         pure
         returns (uint256)
     {
-        uint256 base = 34000;
-        uint256 pair = 45000;
+        uint256 base = 45000;
+        uint256 pair = 34000;
         return base + pair * pubkeyLen;
     }
 

--- a/contracts/libs/BLS.sol
+++ b/contracts/libs/BLS.sol
@@ -126,7 +126,7 @@ library BLS {
     {
         uint256 base = 45000;
         uint256 pair = 34000;
-        return base + pair * pubkeyLen;
+        return base + pair * (pubkeyLen + 1);
     }
 
     /**

--- a/test/fast/bls.test.ts
+++ b/test/fast/bls.test.ts
@@ -79,15 +79,14 @@ describe("BLS", async () => {
             messages.push(mcl.g1ToHex(messagePoint));
             pubkeys.push(mcl.g2ToHex(pubkey));
             signatures.push(signature);
-            if (i >= 1) {
-                const aggSignature = mcl.g1ToHex(mcl.aggregateRaw(signatures));
-                const {
-                    0: checkResult,
-                    1: callSuccess
-                } = await bls.verifyMultiple(aggSignature, pubkeys, messages);
-                assert.isTrue(callSuccess, `call failed i=${i}`);
-                assert.isTrue(checkResult, `check failed i=${i}`);
-            }
+            const aggSignature = mcl.g1ToHex(mcl.aggregateRaw(signatures));
+            const { 0: checkResult, 1: callSuccess } = await bls.verifyMultiple(
+                aggSignature,
+                pubkeys,
+                messages
+            );
+            assert.isTrue(callSuccess, `call failed i=${i}`);
+            assert.isTrue(checkResult, `check failed i=${i}`);
         }
     });
     it("verify aggregated signature: fail bad signature", async function() {

--- a/test/fast/bls.test.ts
+++ b/test/fast/bls.test.ts
@@ -79,11 +79,16 @@ describe("BLS", async () => {
             messages.push(mcl.g1ToHex(messagePoint));
             pubkeys.push(mcl.g2ToHex(pubkey));
             signatures.push(signature);
+            if (i >= 1) {
+                const aggSignature = mcl.g1ToHex(mcl.aggregateRaw(signatures));
+                const {
+                    0: checkResult,
+                    1: callSuccess
+                } = await bls.verifyMultiple(aggSignature, pubkeys, messages);
+                assert.isTrue(callSuccess, `call failed i=${i}`);
+                assert.isTrue(checkResult, `check failed i=${i}`);
+            }
         }
-        const aggSignature = mcl.g1ToHex(mcl.aggregateRaw(signatures));
-        const res = await bls.verifyMultiple(aggSignature, pubkeys, messages);
-        assert.isTrue(res[0]);
-        assert.isTrue(res[1]);
     });
     it("verify aggregated signature: fail bad signature", async function() {
         const n = 10;


### PR DESCRIPTION
### What's wrong

#417 BLS check failed when less or equal than 4 messages.

This is due to 

1. we misplaced the base cost and the per pairing cost of the precompile call. See 
https://github.com/ethereum/go-ethereum/blob/master/params/protocol_params.go#L127 for the ground truth.
2. checking n public keys needs n + 1 pairings

### How can we fix it

Fix the incorrect gas cost computation.

### Note

Could be superseded by #409, as we are trying a new approach to calculate the gas cost