### PR TITLE
Fix #397, add auxiliary fields to genesis.json

### DIFF
--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -33,12 +33,18 @@ async function main() {
     parameters.GENESIS_STATE_ROOT =
         argv.root || getDefaultGenesisRoot(parameters);
 
+    const genesisEth1Block = await provider.getBlockNumber();
     const contracts = await deployAll(signer, parameters, true);
     let addresses: { [key: string]: string } = {};
     Object.keys(contracts).map((contract: string) => {
         addresses[contract] = contracts[contract as keyof allContracts].address;
     });
-    const configs = { parameters, addresses };
+    const appID = await contracts.rollup.appID();
+    const auxiliary = {
+        domain: appID,
+        genesisEth1Block
+    };
+    const configs = { parameters, addresses, auxiliary };
     console.log("Writing genesis.json");
     fs.writeFileSync("genesis.json", JSON.stringify(configs, null, 4));
     console.log("Successsfully deployed", configs);


### PR DESCRIPTION
Genesis now looks like this
```
{
  parameters: {
    MAX_DEPTH: 20,
    MAX_DEPOSIT_SUBTREE_DEPTH: 2,
    STAKE_AMOUNT: '100000000000000000',
    BLOCKS_TO_FINALISE: 40320,
    MIN_GAS_LEFT: 10000,
    MAX_TXS_PER_COMMIT: 32,
    USE_BURN_AUCTION: true,
    DONATION_ADDRESS: '0x00000000000000000000000000000000000000d0',
    DONATION_NUMERATOR: 7500,
    GENESIS_STATE_ROOT: '0x44a6d974c75b07423e1d6d33f481916fdd45830aea11b6347e700cd8b9f0767c'
  },
  addresses: {
    frontendGeneric: '0x2B0d36FACD61B71CC05ab8F3D2355ec3631C0dd5',
    frontendTransfer: '0xfbC22278A96299D91d41C453234d97b4F5Eb9B2d',
    frontendMassMigration: '0x46b142DD1E924FAb83eCc3c08e4D46E82f005e0E',
    frontendCreate2Transfer: '0xC9a43158891282A2B1475592D5719c001986Aaec',
    blsAccountRegistry: '0x367761085BF3C12e5DA2Df99AC6E1a824612b8fb',
    tokenRegistry: '0x4C2F7092C2aE51D986bEFEe378e50BD4dB99C901',
    transfer: '0x49fd2BE640DB2910c2fAb69bB8531Ab6E76127ff',
    massMigration: '0x7A9Ec1d04904907De0ED7b6839CcdD59c3716AC9',
    create2Transfer: '0x4631BCAbD6dF18D94796344963cB60d44a4136b6',
    chooser: '0x1c85638e118b37167e9298c2268758e058DdfDA0',
    exampleToken: '0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D',
    spokeRegistry: '0xAA292E8611aDF267e563f334Ee42320aC96D0463',
    vault: '0x5c74c94173F05dA1720953407cbb920F3DF9f887',
    depositManager: '0x720472c8ce72c2A2D711333e064ABD3E6BbEAdd3',
    rollup: '0xe8D2A1E88c91DCd5433208d4152Cc4F399a7e91d',
    withdrawManager: '0x4b6aB5F819A515382B0dEB6935D793817bB4af28'
  },
  auxiliary: {
    domain: '0xf6c156d7390fc1f367ce4d18c9651c17453b516c63196dfb04dd9ae997a37f42',
    genesisEth1Block: 84
  }
}
```