### PR TITLE
Fix public network deployments

### DIFF
--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -8,12 +8,15 @@ import { StateTree } from "../ts/stateTree";
 import { execSync } from "child_process";
 
 const argv = require("minimist")(process.argv.slice(2), {
-    string: ["url", "root"]
+    string: ["url", "root", "key"]
 });
 /*
     Note separate pubkeys with commas
     > npm run deploy -- --url http://localhost:8545 \
     --root 0x309976060df37ed6961ebd53027fe0c45d3cbbbdfc30a5039e86b2a7aa7fed6e
+
+    You can also specify a private key
+    > npm run deploy -- --key 0xYourPrivateKey 
 */
 
 function getDefaultGenesisRoot(parameters: DeploymentParameters) {
@@ -24,11 +27,12 @@ function getDefaultGenesisRoot(parameters: DeploymentParameters) {
 }
 
 async function main() {
-    const provider = new ethers.providers.JsonRpcProvider(argv.url);
-    const signer = provider.getSigner();
-    // const signer = new ethers.Wallet(
-    //     "0xyourprivatekeyhere"
-    // ).connect(provider);
+    const provider = new ethers.providers.JsonRpcProvider(
+        argv.url ?? "http://localhost:8545"
+    );
+    const signer = argv.key
+        ? new ethers.Wallet(argv.key).connect(provider)
+        : provider.getSigner();
 
     const parameters = PRODUCTION_PARAMS;
     parameters.GENESIS_STATE_ROOT =


### PR DESCRIPTION
This PR fixes a bug in which the deployment fails on a public network like ropsten, because the transactions were not yet mined. It also adds an option to specify the private key from the command line.