### PR TITLE
set account tree first default hash to be 0x290...

### DIFF
--- a/contracts/AccountTree.sol
+++ b/contracts/AccountTree.sol
@@ -25,6 +25,13 @@ contract AccountTree {
     bytes32[DEPTH - BATCH_DEPTH] public filledSubtreesRight;
 
     constructor() public {
+
+            bytes32 firstZero
+         = 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563;
+        // i = 0
+        zeros[0] = firstZero;
+        filledSubtreesLeft[0] = firstZero;
+        // i > 0
         for (uint256 i = 1; i < DEPTH; i++) {
             zeros[i] = keccak256(abi.encode(zeros[i - 1], zeros[i - 1]));
             if (DEPTH > i) {

--- a/contracts/AccountTree.sol
+++ b/contracts/AccountTree.sol
@@ -25,9 +25,8 @@ contract AccountTree {
     bytes32[DEPTH - BATCH_DEPTH] public filledSubtreesRight;
 
     constructor() public {
-
-            bytes32 firstZero
-         = 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563;
+        // prettier-ignore
+        bytes32 firstZero = 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563;
         // i = 0
         zeros[0] = firstZero;
         filledSubtreesLeft[0] = firstZero;

--- a/test/fast/accountTree.test.ts
+++ b/test/fast/accountTree.test.ts
@@ -4,6 +4,7 @@ import { Tree, Hasher } from "../../ts/tree";
 import { ethers } from "hardhat";
 import { assert } from "chai";
 import { randHex, randomLeaves } from "../../ts/utils";
+import { ZERO_BYTES32 } from "../../ts/constants";
 
 let DEPTH: number;
 let BATCH_DEPTH: number;
@@ -17,9 +18,9 @@ describe("Account Tree", async () => {
         accountTree = await new TestAccountTreeFactory(accounts[0]).deploy();
         DEPTH = (await accountTree.DEPTH()).toNumber();
         BATCH_DEPTH = (await accountTree.BATCH_DEPTH()).toNumber();
-        treeLeft = Tree.new(DEPTH);
-        treeRight = Tree.new(DEPTH);
-        hasher = treeLeft.hasher;
+        hasher = Hasher.new("bytes", ZERO_BYTES32);
+        treeLeft = Tree.new(DEPTH, hasher);
+        treeRight = Tree.new(DEPTH, hasher);
     });
     it("empty tree construction", async function() {
         for (let i = 0; i < DEPTH; i++) {

--- a/test/fast/registry.test.ts
+++ b/test/fast/registry.test.ts
@@ -6,6 +6,7 @@ import { Tree, Hasher } from "../../ts/tree";
 import * as mcl from "../../ts/mcl";
 import { ethers } from "hardhat";
 import { assert } from "chai";
+import { ZERO_BYTES32 } from "../../ts/constants";
 
 let DEPTH: number;
 let BATCH_DEPTH: number;
@@ -30,8 +31,9 @@ describe("Registry", async () => {
         registry = await new BlsAccountRegistryFactory(accounts[0]).deploy();
         DEPTH = (await registry.DEPTH()).toNumber();
         BATCH_DEPTH = (await registry.BATCH_DEPTH()).toNumber();
-        treeLeft = Tree.new(DEPTH);
-        treeRight = Tree.new(DEPTH);
+        hasher = Hasher.new("bytes", ZERO_BYTES32);
+        treeLeft = Tree.new(DEPTH, hasher);
+        treeRight = Tree.new(DEPTH, hasher);
         hasher = treeLeft.hasher;
     });
 

--- a/ts/accountTree.ts
+++ b/ts/accountTree.ts
@@ -1,8 +1,9 @@
-import { Tree } from "./tree";
+import { Hasher, Tree } from "./tree";
 import { BlsAccountRegistry } from "../types/ethers-contracts/BlsAccountRegistry";
 import { ethers } from "ethers";
 import { solG2 } from "./mcl";
 import { RegistrationFail, WrongBatchSize } from "./exceptions";
+import { ZERO_BYTES32 } from "./constants";
 
 // Tree is 32 level depth, the index is still smaller than Number.MAX_SAFE_INTEGER
 export class AccountRegistry {
@@ -25,8 +26,10 @@ export class AccountRegistry {
         private readonly depth: number,
         private readonly batchDepth: number
     ) {
-        this.treeLeft = Tree.new(depth);
-        this.treeRight = Tree.new(depth);
+        // Want the treeLeft and treeRight to have default hashes start with ZERO_BYTES32
+        const hasher = Hasher.new("bytes", ZERO_BYTES32);
+        this.treeLeft = Tree.new(depth, hasher);
+        this.treeRight = Tree.new(depth, hasher);
         this.setSize = 2 ** depth;
         this.batchSize = 2 ** batchDepth;
     }


### PR DESCRIPTION
### What's wrong

Currently, we have different default hashes for the state tree and the public key tree. This might confuse client developers and application developers

- first default hash for state tree: `0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563`
- first default hash for public key tree: `0x0000000000000000000000000000000000000000000000000000000000000000`

### How are we fixing it

Make them the same. Set to `0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563`