### PR TITLE
Inherit error properly

### DIFF
--- a/ts/exceptions.ts
+++ b/ts/exceptions.ts
@@ -1,50 +1,166 @@
-export class HubbleError extends Error {}
+export class HubbleError extends Error {
+    constructor(message?: string) {
+        super(message);
+        this.name = "HubbleError";
+    }
+}
 
-export class EncodingError extends HubbleError {}
+export class EncodingError extends HubbleError {
+    constructor(message?: string) {
+        super(message);
+        this.name = "EncodingError";
+    }
+}
 
-export class MismatchByteLength extends HubbleError {}
+export class MismatchByteLength extends HubbleError {
+    constructor(message?: string) {
+        super(message);
+        this.name = "MismatchByteLength";
+    }
+}
 
-export class GenesisNotSpecified extends HubbleError {}
+export class GenesisNotSpecified extends HubbleError {
+    constructor(message?: string) {
+        super(message);
+        this.name = "GenesisNotSpecified";
+    }
+}
 
-export class UserNotExist extends HubbleError {}
+export class UserNotExist extends HubbleError {
+    constructor(message?: string) {
+        super(message);
+        this.name = "UserNotExist";
+    }
+}
 
-export class TreeException extends HubbleError {}
+export class TreeException extends HubbleError {
+    constructor(message?: string) {
+        super(message);
+        this.name = "TreeException";
+    }
+}
 
-class AccountTreeException extends HubbleError {}
+class AccountTreeException extends HubbleError {
+    constructor(message?: string) {
+        super(message);
+        this.name = "AccountTreeException";
+    }
+}
 
-class StateTreeExceptions extends HubbleError {}
+class StateTreeExceptions extends HubbleError {
+    constructor(message?: string) {
+        super(message);
+        this.name = "StateTreeExceptions";
+    }
+}
 
 // TreeException
 
-export class ExceedTreeSize extends TreeException {}
+export class ExceedTreeSize extends TreeException {
+    constructor(message?: string) {
+        super(message);
+        this.name = "ExceedTreeSize";
+    }
+}
 
-export class BadMergeAlignment extends TreeException {}
+export class BadMergeAlignment extends TreeException {
+    constructor(message?: string) {
+        super(message);
+        this.name = "BadMergeAlignment";
+    }
+}
 
-export class EmptyArray extends TreeException {}
+export class EmptyArray extends TreeException {
+    constructor(message?: string) {
+        super(message);
+        this.name = "EmptyArray";
+    }
+}
 
-export class MismatchLength extends TreeException {}
+export class MismatchLength extends TreeException {
+    constructor(message?: string) {
+        super(message);
+        this.name = "MismatchLength";
+    }
+}
 
-export class MismatchHash extends TreeException {}
+export class MismatchHash extends TreeException {
+    constructor(message?: string) {
+        super(message);
+        this.name = "MismatchHash";
+    }
+}
 
-export class NegativeIndex extends TreeException {}
+export class NegativeIndex extends TreeException {
+    constructor(message?: string) {
+        super(message);
+        this.name = "NegativeIndex";
+    }
+}
 
 // AccountTreeException
-export class RegistrationFail extends AccountTreeException {}
+export class RegistrationFail extends AccountTreeException {
+    constructor(message?: string) {
+        super(message);
+        this.name = "HubbleError";
+        RegistrationFail;
+    }
+}
 
-export class WrongBatchSize extends AccountTreeException {}
+export class WrongBatchSize extends AccountTreeException {
+    constructor(message?: string) {
+        super(message);
+        this.name = "WrongBatchSize";
+    }
+}
 
 // StateTreeExceptions
 
-export class ExceedStateTreeSize extends StateTreeExceptions {}
+export class ExceedStateTreeSize extends StateTreeExceptions {
+    constructor(message?: string) {
+        super(message);
+        this.name = "ExceedStateTreeSize";
+    }
+}
 
-export class SenderNotExist extends StateTreeExceptions {}
+export class SenderNotExist extends StateTreeExceptions {
+    constructor(message?: string) {
+        super(message);
+        this.name = "SenderNotExist";
+    }
+}
 
-export class ReceiverNotExist extends StateTreeExceptions {}
+export class ReceiverNotExist extends StateTreeExceptions {
+    constructor(message?: string) {
+        super(message);
+        this.name = "ReceiverNotExist";
+    }
+}
 
-export class StateAlreadyExist extends StateTreeExceptions {}
+export class StateAlreadyExist extends StateTreeExceptions {
+    constructor(message?: string) {
+        super(message);
+        this.name = "StateAlreadyExist";
+    }
+}
 
-export class WrongTokenID extends StateTreeExceptions {}
+export class WrongTokenID extends StateTreeExceptions {
+    constructor(message?: string) {
+        super(message);
+        this.name = "WrongTokenID";
+    }
+}
 
-export class InsufficientFund extends StateTreeExceptions {}
+export class InsufficientFund extends StateTreeExceptions {
+    constructor(message?: string) {
+        super(message);
+        this.name = "InsufficientFund";
+    }
+}
 
-export class ZeroAmount extends StateTreeExceptions {}
+export class ZeroAmount extends StateTreeExceptions {
+    constructor(message?: string) {
+        super(message);
+        this.name = "ZeroAmount";
+    }
+}


### PR DESCRIPTION
### What's wrong

Creating custom exception classes by extending the base exception class is slightly more difficult to do right than what we are doing now.

Mocha doesn't show the exception name under the current approach.

Before 

```
 Frontend
    1) "before all" hook for "test transfer"


  0 passing (2s)
  1 failing

  1) Frontend
       "before all" hook for "test transfer":
   
      at Object.deployAll (ts/deploy.ts:123:47)
      at runMicrotasks (<anonymous>)
      at processTicksAndRejections (internal/process/task_queues.js:94:5)
      at Context.<anonymous> (test/fast/frontends.test.ts:15:21)

```

After

```
 Frontend
    1) "before all" hook for "test transfer"


  0 passing (2s)
  1 failing

  1) Frontend
       "before all" hook for "test transfer":
     
  GenesisNotSpecified: 
      at Object.deployAll (ts/deploy.ts:123:47)
      at runMicrotasks (<anonymous>)
      at processTicksAndRejections (internal/process/task_queues.js:94:5)
      at Context.<anonymous> (test/fast/frontends.test.ts:15:21)

```