### PR TITLE
Add account root to log

### DIFF
--- a/contracts/rollup/BatchManager.sol
+++ b/contracts/rollup/BatchManager.sol
@@ -33,12 +33,7 @@ contract BatchManager is Parameters {
     // will be reset to 0 once rollback is completed
     uint256 public invalidBatchMarker;
 
-    event NewBatch(
-        address committer,
-        uint256 index,
-        bytes32 accountRoot,
-        Types.Usage batchType
-    );
+    event NewBatch(uint256 batchID, bytes32 accountRoot, Types.Usage batchType);
     event StakeWithdraw(address committed, uint256 batchID);
     event RollbackStatus(uint256 startID, uint256 nDeleted, bool completed);
 
@@ -130,7 +125,7 @@ contract BatchManager is Parameters {
                 block.number + paramBlocksToFinalise
             )
         });
-        emit NewBatch(msg.sender, nextBatchID, accountRoot, batchType);
+        emit NewBatch(nextBatchID, accountRoot, batchType);
         nextBatchID++;
     }
 

--- a/contracts/rollup/BatchManager.sol
+++ b/contracts/rollup/BatchManager.sol
@@ -33,7 +33,12 @@ contract BatchManager is Parameters {
     // will be reset to 0 once rollback is completed
     uint256 public invalidBatchMarker;
 
-    event NewBatch(address committer, uint256 index, Types.Usage batchType);
+    event NewBatch(
+        address committer,
+        uint256 index,
+        bytes32 accountRoot,
+        Types.Usage batchType
+    );
     event StakeWithdraw(address committed, uint256 batchID);
     event RollbackStatus(uint256 startID, uint256 nDeleted, bool completed);
 
@@ -112,6 +117,7 @@ contract BatchManager is Parameters {
     function submitBatch(
         bytes32 commitmentRoot,
         uint256 size,
+        bytes32 accountRoot,
         Types.Usage batchType
     ) internal {
         require(msg.value >= paramStakeAmount, "Rollup: wrong stake amount");
@@ -124,7 +130,7 @@ contract BatchManager is Parameters {
                 block.number + paramBlocksToFinalise
             )
         });
-        emit NewBatch(msg.sender, nextBatchID, batchType);
+        emit NewBatch(msg.sender, nextBatchID, accountRoot, batchType);
         nextBatchID++;
     }
 

--- a/contracts/rollup/Rollup.sol
+++ b/contracts/rollup/Rollup.sol
@@ -452,7 +452,7 @@ contract Rollup is RollupCore {
                 block.number // genesis finalise instantly
             )
         });
-        emit NewBatch(msg.sender, nextBatchID, bytes32(0), Types.Usage.Genesis);
+        emit NewBatch(nextBatchID, bytes32(0), Types.Usage.Genesis);
         nextBatchID++;
         appID = keccak256(abi.encodePacked(address(this)));
     }

--- a/contracts/rollup/Rollup.sol
+++ b/contracts/rollup/Rollup.sol
@@ -133,6 +133,7 @@ contract RollupCore is BatchManager {
         submitBatch(
             MerkleTree.merklise(leaves),
             stateRoots.length,
+            accountRoot,
             Types.Usage.Transfer
         );
     }
@@ -164,6 +165,7 @@ contract RollupCore is BatchManager {
         submitBatch(
             MerkleTree.merklise(leaves),
             stateRoots.length,
+            accountRoot,
             Types.Usage.Create2Transfer
         );
     }
@@ -199,6 +201,7 @@ contract RollupCore is BatchManager {
         submitBatch(
             MerkleTree.merklise(leaves),
             stateRoots.length,
+            accountRoot,
             Types.Usage.MassMigration
         );
     }
@@ -241,7 +244,7 @@ contract RollupCore is BatchManager {
         );
         // Same effect as `MerkleTree.merklise`
         bytes32 root = keccak256(abi.encode(depositCommitment, ZERO_BYTES32));
-        submitBatch(root, 1, Types.Usage.Deposit);
+        submitBatch(root, 1, bytes32(0), Types.Usage.Deposit);
     }
 
     function disputeTransitionTransfer(
@@ -449,7 +452,7 @@ contract Rollup is RollupCore {
                 block.number // genesis finalise instantly
             )
         });
-        emit NewBatch(msg.sender, nextBatchID, Types.Usage.Genesis);
+        emit NewBatch(msg.sender, nextBatchID, bytes32(0), Types.Usage.Genesis);
         nextBatchID++;
         appID = keccak256(abi.encodePacked(address(this)));
     }

--- a/contracts/rollup/Rollup.sol
+++ b/contracts/rollup/Rollup.sol
@@ -244,6 +244,7 @@ contract RollupCore is BatchManager {
         );
         // Same effect as `MerkleTree.merklise`
         bytes32 root = keccak256(abi.encode(depositCommitment, ZERO_BYTES32));
+        // AccountRoot doesn't matter for deposit, add dummy value
         submitBatch(root, 1, bytes32(0), Types.Usage.Deposit);
     }
 
@@ -452,6 +453,7 @@ contract Rollup is RollupCore {
                 block.number // genesis finalise instantly
             )
         });
+        // AccountRoot doesn't matter for genesis, add dummy value
         emit NewBatch(nextBatchID, bytes32(0), Types.Usage.Genesis);
         nextBatchID++;
         appID = keccak256(abi.encodePacked(address(this)));

--- a/contracts/test/TestRollup.sol
+++ b/contracts/test/TestRollup.sol
@@ -32,12 +32,12 @@ contract TestRollup is BatchManager {
     }
 
     function submitDummyBatch() external payable {
-        submitBatch(bytes32(0), 0, Types.Usage.Transfer);
+        submitBatch(bytes32(0), 0, bytes32(0), Types.Usage.Transfer);
     }
 
     function submitDeposits(bytes32 depositSubTreeRoot) external payable {
         deposits[nextBatchID] = depositSubTreeRoot;
-        submitBatch(bytes32(0), 0, Types.Usage.Transfer);
+        submitBatch(bytes32(0), 0, bytes32(0), Types.Usage.Transfer);
     }
 
     function testRollback(uint256 batchID) external returns (uint256) {


### PR DESCRIPTION
### What's wrong

- We currently don't emit account tree root when submitting batch. The coordinator has no way to know what account tree root  is used to create the batch
- The msg sender in the new batch log is kind of redundant. The same information can be acquired from the view function of the batch meta.

### How are we fixing it

We remove the msg sender field and add account tree root field. So the tps for transfer/mm/c2t remains to be the same.