### PR TITLE
remove amount greater than 0 requirement

### DIFF
--- a/contracts/DepositManager.sol
+++ b/contracts/DepositManager.sol
@@ -118,8 +118,6 @@ contract DepositManager is DepositCore, IDepositManager {
         uint256 amount,
         uint256 tokenID
     ) external {
-        // check amount is greater than 0
-        require(amount > 0, "token deposit must be greater than 0");
         IERC20 tokenContract = IERC20(tokenRegistry.safeGetAddress(tokenID));
         // transfer from msg.sender to vault
         require(


### PR DESCRIPTION
### What's wrong

As mentioned in #390, the deposit manager currently requires a non-zero amount. If people register a new token in the token registry, the coordinators then need to have an L2 state to serve that token. But the deposit manager's "amount > 0" restriction means the coordinator needs to hold some of that token to deposit.

The reason to have that restriction in the first place is to prevent the deposit function from being DoSed. But if the token is already a shitcoin, the restriction means nothing.

We could argue that paying gas is already mitigating DoS to some degree. And we can add more other measures in the future.
