### PR TITLE
Separate Float and FixedNumber

### DIFF
--- a/test/fast/decimal.test.ts
+++ b/test/fast/decimal.test.ts
@@ -1,26 +1,40 @@
 import { assert } from "chai";
-import { USDT } from "../../ts/decimal";
+import { float16, USDT } from "../../ts/decimal";
 
 describe("Decimal", () => {
-    const goodCases: number[] = [0, 1, 10000, 12.13, 0.1234, 18690000000];
-
     it("Get's some property right", () => {
-        assert.equal(USDT.bytesLength, 2);
+        assert.equal(float16.bytesLength, 2);
     });
 
-    it("casts values", () => {
-        for (const value of goodCases) {
+    it("Rounding values", () => {
+        const losslessCases: number[] = [
+            0,
+            1,
+            10000,
+            12.13,
+            0.1234,
+            18690000000
+        ];
+        for (const value of losslessCases) {
+            const valueBN = USDT.parse(value.toString());
             assert.equal(
-                USDT.cast(value),
-                value,
+                float16.round(valueBN).toString(),
+                valueBN.toString(),
                 "Casted value should be the same in good cases"
             );
         }
-        assert.equal(USDT.cast(0.12345), 0.1234);
-        assert.equal(USDT.cast(56789), 56700);
-        assert.equal(USDT.cast(123.123), 123.1);
-        assert.equal(USDT.cast(186950000000), 186900000000);
-        assert.equal(USDT.cast(4096), 4090);
-        assert.equal(USDT.cast(4095), 4095);
+        const lossyCases = [
+            { input: 0.12345, expect: 0.1234 },
+            { input: 56789, expect: 56700 },
+            { input: 123.123, expect: 123.1 },
+            { input: 186950000000, expect: 186900000000 },
+            { input: 4096, expect: 4090 },
+            { input: 4095, expect: 4095 }
+        ];
+        for (const _case of lossyCases) {
+            const valueBN = USDT.parse(_case.input.toString());
+            const valueRounded = float16.round(valueBN);
+            assert.equal(Number(USDT.format(valueRounded)), _case.expect);
+        }
     });
 });

--- a/test/fast/decimal.test.ts
+++ b/test/fast/decimal.test.ts
@@ -1,6 +1,5 @@
 import { assert } from "chai";
 import { USDT } from "../../ts/decimal";
-import { EncodingError } from "../../ts/exceptions";
 
 describe("Decimal", () => {
     const goodCases: number[] = [0, 1, 10000, 12.13, 0.1234, 18690000000];
@@ -9,35 +8,6 @@ describe("Decimal", () => {
         assert.equal(USDT.bytesLength, 2);
     });
 
-    it("Compresses and decompresses values", () => {
-        for (const value of goodCases) {
-            assert.equal(
-                USDT.decode(USDT.encode(value)),
-                value,
-                `Mismatch Encode and decode of ${value}`
-            );
-        }
-    });
-    it("Compresses and decompresses random values", () => {
-        let value: number;
-        for (let i = 0; i <= 20; i++) {
-            value = USDT.randNum();
-            assert.equal(
-                USDT.decode(USDT.encode(value)),
-                value,
-                `Mismatch Encode and decode of ${value}`
-            );
-        }
-    });
-
-    it("throws for bad cases", () => {
-        const failingCases: number[] = [0.12345, 56789, 123.123];
-        for (const value of failingCases) {
-            assert.throws(() => {
-                USDT.encode(value);
-            }, EncodingError);
-        }
-    });
     it("casts values", () => {
         for (const value of goodCases) {
             assert.equal(

--- a/test/fast/txSerialization.test.ts
+++ b/test/fast/txSerialization.test.ts
@@ -9,8 +9,9 @@ import {
 import { assert } from "chai";
 import { ethers } from "hardhat";
 import { COMMIT_SIZE } from "../../ts/constants";
-import { USDT } from "../../ts/decimal";
+import { float16 } from "../../ts/decimal";
 import { BigNumber } from "ethers";
+import { hexZeroPad } from "ethers/lib/utils";
 
 describe("Tx Serialization", async () => {
     let c: TestTx;
@@ -140,10 +141,10 @@ describe("Tx Serialization", async () => {
         ];
         const fuzzCases = [];
         for (let i = 0; i < 100; i++) {
-            fuzzCases.push(USDT.randInt().toString());
+            fuzzCases.push(float16.randInt().toString());
         }
         for (const caseN of edgeCases.concat(fuzzCases)) {
-            const expect = BigNumber.from(USDT.encodeInt(caseN)).toString();
+            const expect = BigNumber.from(float16.compress(caseN)).toString();
             try {
                 const actual = await c.testEncodeDecimal(caseN);
                 assert.equal(actual.toString(), expect);

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -144,7 +144,7 @@ describe("Integration Test", function() {
             initialPubkeyID: 0,
             domain
         }).connect(stateTree);
-        const balance = USDT.castInt(1234.0);
+        const balance = USDT.parse("1234.0");
         const fromBlockNumber = await deployer.provider?.getBlockNumber();
         for (const user of earlyAdopters.userIterator()) {
             const pubkeyID = await accountRegistry.register(user.pubkey);

--- a/test/slow/rollup.create2Transfer.test.ts
+++ b/test/slow/rollup.create2Transfer.test.ts
@@ -50,7 +50,7 @@ describe("Rollup Create2Transfer", async function() {
         });
         stateTree = new StateTree(TESTING_PARAMS.MAX_DEPTH);
 
-        const initialBalance = USDT.castInt(55.6);
+        const initialBalance = USDT.parse("55.6");
         usersWithStates
             .connect(stateTree)
             .createStates({ initialBalance, tokenID, zeroNonce: true });

--- a/test/slow/rollup.massMigration.test.ts
+++ b/test/slow/rollup.massMigration.test.ts
@@ -8,7 +8,7 @@ import * as mcl from "../../ts/mcl";
 import { allContracts } from "../../ts/allContractsInterfaces";
 import { assert } from "chai";
 import { getGenesisProof, MassMigrationCommitment } from "../../ts/commitments";
-import { USDT } from "../../ts/decimal";
+import { float16, USDT } from "../../ts/decimal";
 import { Result } from "../../ts/interfaces";
 import { expectRevert, hexToUint8Array, mineBlocks } from "../../ts/utils";
 import { Group, txMassMigrationFactory } from "../../ts/factory";
@@ -30,7 +30,7 @@ describe("Mass Migrations", async function() {
         const [signer] = await ethers.getSigners();
         users = Group.new({ n: 32, initialStateID: 0, initialPubkeyID: 0 });
         stateTree = new StateTree(TESTING_PARAMS.MAX_DEPTH);
-        const initialBalance = USDT.castInt(1000);
+        const initialBalance = USDT.parse("1000");
         users
             .connect(stateTree)
             .createStates({ initialBalance, tokenID, zeroNonce: false });
@@ -123,11 +123,11 @@ describe("Mass Migrations", async function() {
         const aliceState = stateTree.getState(alice.stateID).state;
         const tx = new TxMassMigration(
             alice.stateID,
-            USDT.castInt(39.99),
+            USDT.parse("39.99"),
             1,
-            USDT.castInt(0.01),
+            USDT.parse("0.01"),
             aliceState.nonce + 1,
-            USDT
+            float16
         );
         stateTree.processMassMigrationCommit([tx], feeReceiver);
 

--- a/test/slow/rollup.transfer.test.ts
+++ b/test/slow/rollup.transfer.test.ts
@@ -40,7 +40,7 @@ describe("Rollup", async function() {
 
         stateTree = new StateTree(TESTING_PARAMS.MAX_DEPTH);
 
-        const initialBalance = USDT.castInt(55.6);
+        const initialBalance = USDT.parse("55.6");
         users
             .connect(stateTree)
             .createStates({ initialBalance, tokenID, zeroNonce: true });

--- a/ts/decimal.ts
+++ b/ts/decimal.ts
@@ -44,6 +44,14 @@ export class Float {
         this.bytesLength = (mantissaBits + exponentBits) / 8;
     }
 
+    public rand(): string {
+        return randHex(this.bytesLength);
+    }
+
+    public randInt(): BigNumber {
+        return this.decompress(this.rand());
+    }
+
     public compress(input: BigNumberish): string {
         let exponent = 0;
         let mantissa = BigNumber.from(input.toString());

--- a/ts/decimal.ts
+++ b/ts/decimal.ts
@@ -52,6 +52,19 @@ export class Float {
         return this.decompress(this.rand());
     }
 
+    /**
+     * Round the input down to a compressible number.
+     */
+    public round(input: BigNumber): BigNumber {
+        let mantissa = input;
+        for (let exponent = 0; exponent < this.exponentMax; exponent++) {
+            if (mantissa.lte(this.mantissaMax))
+                return mantissa.mul(BigNumber.from(10).pow(exponent));
+            mantissa = mantissa.div(10);
+        }
+        throw new EncodingError(`Can't cast input ${input.toString()}`);
+    }
+
     public compress(input: BigNumberish): string {
         let mantissa = BigNumber.from(input.toString());
         let exponent = 0;

--- a/ts/decimal.ts
+++ b/ts/decimal.ts
@@ -53,26 +53,22 @@ export class Float {
     }
 
     public compress(input: BigNumberish): string {
-        let exponent = 0;
         let mantissa = BigNumber.from(input.toString());
-        for (let i = 0; i < this.exponentMax; i++) {
-            if (!mantissa.isZero() && mantissa.mod(10).isZero()) {
-                mantissa = mantissa.div(10);
-                exponent += 1;
-            } else {
-                break;
-            }
+        let exponent = 0;
+        for (; exponent < this.exponentMax; exponent++) {
+            if (mantissa.isZero() || !mantissa.mod(10).isZero()) break;
+            mantissa = mantissa.div(10);
         }
-        if (mantissa.gt(this.mantissaMax)) {
+        if (mantissa.gt(this.mantissaMax))
             throw new EncodingError(
-                `Can not encode input ${input}, mantissa ${mantissa} should not be larger than ${this.mantissaMax}`
+                `Cannot compress ${input}, expect mantissa ${mantissa} <= ${this.mantissaMax}`
             );
-        }
+
         const hex = BigNumber.from(exponent)
             .shl(this.mantissaBits)
             .add(mantissa)
             .toHexString();
-        return ethers.utils.hexZeroPad(hex, this.bytesLength);
+        return hexZeroPad(hex, this.bytesLength);
     }
     public decompress(input: BytesLike): BigNumber {
         const mantissa = this.mantissaMax.and(input);

--- a/ts/decimal.ts
+++ b/ts/decimal.ts
@@ -108,10 +108,6 @@ export class DecimalCodec {
         return this.decodeInt(this.rand());
     }
 
-    public randNum(): number {
-        return this.decode(this.rand());
-    }
-
     /**
      * Given an arbitrary js number returns a js number that can be encoded.
      */
@@ -147,23 +143,6 @@ export class DecimalCodec {
             mantissa = mantissa.div(10);
         }
         throw new EncodingError(`Can't cast input ${input.toString()}`);
-    }
-
-    public encode(input: number) {
-        // Use Math.round here to prevent the case
-        // > 32.3 * 10 ** 6
-        // 32299999.999999996
-        const integer = Math.round(input * 10 ** this.place);
-        return this.encodeInt(integer);
-    }
-    public decode(input: BytesLike): number {
-        const integer = this.decodeInt(input);
-        const tens = BigNumber.from(10).pow(this.place);
-        if (integer.gte(Number.MAX_SAFE_INTEGER.toString())) {
-            return integer.div(tens).toNumber();
-        } else {
-            return integer.toNumber() / tens.toNumber();
-        }
     }
 
     public encodeInt(input: BigNumberish): string {

--- a/ts/decimal.ts
+++ b/ts/decimal.ts
@@ -3,31 +3,27 @@ import { formatUnits, hexZeroPad, parseUnits } from "ethers/lib/utils";
 import { EncodingError } from "./exceptions";
 import { randHex } from "./utils";
 
-/**
- * Parse the human readable value like "1.23" to the ERC20 integer amount.
- * @param humanValue could be a fractional number but is string. Like '1.23'
- * @param decimals The ERC20 decimals()
- * @returns the ERC20 integer amount. Like '1230000000000000000' but in BigNumber
- */
-export function parseERC20(
-    humanValue: string,
-    decimals: number = 18
-): BigNumber {
-    return parseUnits(humanValue, decimals);
+export class ERC20 {
+    constructor(public decimals: number = 18) {}
+    /**
+     * Parse the human readable value like "1.23" to the ERC20 integer amount.
+     * @param humanValue could be a fractional number but is string. Like '1.23'
+     * @returns the ERC20 integer amount. Like '1230000000000000000' but in BigNumber
+     */
+    parse(humanValue: string) {
+        return parseUnits(humanValue, this.decimals);
+    }
+    /**
+     * Format the ERC20 integer amount to human readable value.
+     * @param uint256Value is an integer like '1230000000000000000'
+     * @returns Could be a fractional number but in string. Like '1.23'
+     */
+    format(uint256Value: BigNumberish) {
+        return formatUnits(uint256Value, this.decimals);
+    }
 }
 
-/**
- * Format the ERC20 integer amount to human readable value.
- * @param uint256Value is an integer like '1230000000000000000'
- * @param decimals The ERC20 decimals()
- * @returns Could be a fractional number but in string. Like '1.23'
- */
-export function formatERC20(
-    uint256Value: BigNumberish,
-    decimals: number = 18
-): string {
-    return formatUnits(uint256Value, decimals);
-}
+export const USDT = new ERC20(6);
 
 export class Float {
     private mantissaMax: BigNumber;
@@ -91,97 +87,4 @@ export class Float {
     }
 }
 
-export const float2 = new Float(4, 12);
-
-export class DecimalCodec {
-    private mantissaMax: BigNumber;
-    private exponentMax: number;
-    private exponentMask: BigNumber;
-    public bytesLength: number;
-
-    constructor(
-        public readonly exponentBits: number,
-        public readonly mantissaBits: number,
-        public readonly place: number
-    ) {
-        this.mantissaMax = BigNumber.from(2 ** mantissaBits - 1);
-        this.exponentMax = 2 ** exponentBits - 1;
-        this.exponentMask = BigNumber.from(this.exponentMax << mantissaBits);
-        this.bytesLength = (mantissaBits + exponentBits) / 8;
-    }
-    public rand(): string {
-        return randHex(this.bytesLength);
-    }
-
-    public randInt(): BigNumber {
-        return this.decodeInt(this.rand());
-    }
-
-    /**
-     * Given an arbitrary js number returns a js number that can be encoded.
-     */
-    public cast(input: number): number {
-        if (input == 0) {
-            return input;
-        }
-
-        const logMantissaMax = Math.log10(this.mantissaMax.toNumber());
-        const logInput = Math.log10(input);
-        const exponent = Math.floor(logMantissaMax - logInput);
-        const mantissa = Math.floor(input * 10 ** exponent);
-
-        return mantissa / 10 ** exponent;
-    }
-
-    /**
-     * Given an arbitrary js number returns a integer that can be encoded
-     */
-    public castInt(input: number): BigNumber {
-        const validNum = this.cast(input);
-        return BigNumber.from(Math.round(validNum * 10 ** this.place));
-    }
-
-    /**
-     * Find a BigNumber that's less than the input and compressable
-     */
-    public castBigNumber(input: BigNumber): BigNumber {
-        let mantissa = input;
-        for (let exponent = 0; exponent < this.exponentMax; exponent++) {
-            if (mantissa.lte(this.mantissaMax))
-                return mantissa.mul(BigNumber.from(10).pow(exponent));
-            mantissa = mantissa.div(10);
-        }
-        throw new EncodingError(`Can't cast input ${input.toString()}`);
-    }
-
-    public encodeInt(input: BigNumberish): string {
-        let exponent = 0;
-        let mantissa = BigNumber.from(input.toString());
-        for (let i = 0; i < this.exponentMax; i++) {
-            if (!mantissa.isZero() && mantissa.mod(10).isZero()) {
-                mantissa = mantissa.div(10);
-                exponent += 1;
-            } else {
-                break;
-            }
-        }
-        if (mantissa.gt(this.mantissaMax)) {
-            throw new EncodingError(
-                `Can not encode input ${input}, mantissa ${mantissa} should not be larger than ${this.mantissaMax}`
-            );
-        }
-        const hex = BigNumber.from(exponent)
-            .shl(this.mantissaBits)
-            .add(mantissa)
-            .toHexString();
-        return ethers.utils.hexZeroPad(hex, this.bytesLength);
-    }
-    public decodeInt(input: BytesLike): BigNumber {
-        const mantissa = this.mantissaMax.and(input);
-        const exponent = this.exponentMask.and(input).shr(this.mantissaBits);
-
-        return mantissa.mul(BigNumber.from(10).pow(exponent));
-    }
-}
-
-export const USDT = new DecimalCodec(4, 12, 6);
+export const float16 = new Float(4, 12);

--- a/ts/decimal.ts
+++ b/ts/decimal.ts
@@ -1,22 +1,32 @@
 import { BigNumber, BigNumberish, BytesLike, ethers } from "ethers";
-import { hexZeroPad } from "ethers/lib/utils";
+import { formatUnits, hexZeroPad, parseUnits } from "ethers/lib/utils";
 import { EncodingError } from "./exceptions";
 import { randHex } from "./utils";
 
+/**
+ * Parse the human readable value like "1.23" to the ERC20 integer amount.
+ * @param humanValue could be a fractional number but is string. Like '1.23'
+ * @param decimals The ERC20 decimals()
+ * @returns the ERC20 integer amount. Like '1230000000000000000' but in BigNumber
+ */
 export function parseERC20(
-    humanValue: number,
+    humanValue: string,
     decimals: number = 18
 ): BigNumber {
-    const multiplier = Math.pow(10, decimals);
-    return BigNumber.from(humanValue).div(multiplier);
+    return parseUnits(humanValue, decimals);
 }
 
+/**
+ * Format the ERC20 integer amount to human readable value.
+ * @param uint256Value is an integer like '1230000000000000000'
+ * @param decimals The ERC20 decimals()
+ * @returns Could be a fractional number but in string. Like '1.23'
+ */
 export function formatERC20(
     uint256Value: BigNumberish,
     decimals: number = 18
-): BigNumber {
-    const multiplier = Math.pow(10, decimals);
-    return BigNumber.from(uint256Value).mul(multiplier);
+): string {
+    return formatUnits(uint256Value, decimals);
 }
 
 export class Float {
@@ -27,7 +37,7 @@ export class Float {
     constructor(
         public readonly exponentBits: number,
         public readonly mantissaBits: number
-    ){
+    ) {
         this.mantissaMax = BigNumber.from(2 ** mantissaBits - 1);
         this.exponentMax = 2 ** exponentBits - 1;
         this.exponentMask = BigNumber.from(this.exponentMax << mantissaBits);
@@ -64,9 +74,7 @@ export class Float {
     }
 }
 
-export const float2 = new Float(4, 12)
-
-
+export const float2 = new Float(4, 12);
 
 export class DecimalCodec {
     private mantissaMax: BigNumber;

--- a/ts/factory.ts
+++ b/ts/factory.ts
@@ -5,7 +5,7 @@ import {
     BlsSignerInterface,
     nullBlsSigner
 } from "./blsSigner";
-import { USDT } from "./decimal";
+import { float16, USDT } from "./decimal";
 import { UserNotExist } from "./exceptions";
 import { Domain, solG1 } from "./mcl";
 import { State } from "./state";
@@ -148,7 +148,7 @@ export class Group {
         return states;
     }
     public createStates(options?: createStateOptions) {
-        const initialBalance = options?.initialBalance || USDT.castInt(1000.0);
+        const initialBalance = options?.initialBalance || USDT.parse("1000.0");
         const tokenID = options?.tokenID === undefined ? 5678 : options.tokenID;
         const zeroNonce = options?.zeroNonce || false;
         const arbitraryInitialNonce = 9;
@@ -179,8 +179,8 @@ export function txTransferFactory(
         const sender = group.getUser(i % group.size);
         const receiver = group.getUser((i + 5) % group.size);
         const senderState = group.getState(sender);
-        const amount = USDT.castBigNumber(senderState.balance.div(10));
-        const fee = USDT.castBigNumber(amount.div(10));
+        const amount = float16.round(senderState.balance.div(10));
+        const fee = float16.round(amount.div(10));
         const nonce = seenNonce[sender.stateID]
             ? seenNonce[sender.stateID] + 1
             : senderState.nonce;
@@ -191,7 +191,7 @@ export function txTransferFactory(
             amount,
             fee,
             nonce,
-            USDT
+            float16
         );
         txs.push(tx);
         signatures.push(sender.sign(tx));
@@ -215,8 +215,8 @@ export function txCreate2TransferFactory(
         const sender = registered.getUser(i % registered.size);
         const reciver = unregistered.getUser(i % unregistered.size);
         const senderState = registered.getState(sender);
-        const amount = USDT.castBigNumber(senderState.balance.div(10));
-        const fee = USDT.castBigNumber(amount.div(10));
+        const amount = float16.round(senderState.balance.div(10));
+        const fee = float16.round(amount.div(10));
         const nonce = seenNonce[sender.stateID]
             ? seenNonce[sender.stateID] + 1
             : senderState.nonce;
@@ -230,7 +230,7 @@ export function txCreate2TransferFactory(
             amount,
             fee,
             nonce,
-            USDT
+            float16
         );
         txs.push(tx);
         signatures.push(sender.sign(tx));
@@ -250,8 +250,8 @@ export function txMassMigrationFactory(
     const seenNonce: { [stateID: number]: number } = {};
     for (const sender of group.userIterator()) {
         const senderState = group.getState(sender);
-        const amount = USDT.castBigNumber(senderState.balance.div(10));
-        const fee = USDT.castBigNumber(amount.div(10));
+        const amount = float16.round(senderState.balance.div(10));
+        const fee = float16.round(amount.div(10));
         const nonce = seenNonce[sender.stateID]
             ? seenNonce[sender.stateID] + 1
             : senderState.nonce;
@@ -263,7 +263,7 @@ export function txMassMigrationFactory(
             spokeID,
             fee,
             nonce,
-            USDT
+            float16
         );
         txs.push(tx);
         signatures.push(sender.sign(tx));


### PR DESCRIPTION
### What's wrong

A source of confusion for handling the value of amount and fees is we mixed the float compression and fixed number parsing/formatting in the same class DecimalCodec.

Let's expand on the fixed number and the floating number.

"[FixedNumber](https://docs.ethers.io/v5/api/utils/fixednumber/) is a fixed-width (in bits) number with an internal base-10 divisor, which allows it to represent a decimal fractional component."  

Fixed number  is how we parse and interpret the ERC20 token value. An ERC20 token TKN with decimal 18 means "1.23 TKN" is stored as the integer 1.23*10^18 on-chain. It is "ufixed128x18" in the notion of [fixedFormat](https://docs.ethers.io/v5/api/utils/fixednumber/#FixedFormat--strings) as it is unsigned, taking 128 bits, and having 18 decimals.

Floating Number is the way we compress the transfer amount and fee values to save gas in calldata. We compress the fixed number value from 128 bits to the 16 bits floating number. To get the idea of the gas costs saving, it [costs](https://github.com/ethereum/go-ethereum/blob/master/params/protocol_params.go) 4 gas per zero bytes and 16 gas per non-zero bytes in the calldata.

We used to avoid the term compress/decompress because it indicates loss (in precision). In terms of the onchain operation, the compression/decompression is lossless. But it's lossy in terms of the value you want to send. For example, you can't send "1.2345" TKN, you must round it down to  "1.234" TKN. See `test/fast/decimal.test.ts` for more examples.
I would argue if the whole purpose of the floating number is to reduce the size of the data, then calling it compression should be fine.


### How are we fixing it

We separate the Fixed number operations and the floating-point compressions by replacing the DecimalCodec class with the ERC20 class and the float class.

Note: No contract change.