### PR TITLE
Register token in different decimals

### DIFF
--- a/contracts/DepositManager.sol
+++ b/contracts/DepositManager.sol
@@ -126,7 +126,7 @@ contract DepositManager is DepositCore, IDepositManager {
     ) external {
         (address addr, uint256 l2Unit) = tokenRegistry.safeGetRecord(tokenID);
         require(
-            l1Amount % l2Unit == 0,
+            l1Amount == 0 || l1Amount % l2Unit == 0,
             "l1Amount should be a multiple of l2Unit"
         );
         // transfer from msg.sender to vault

--- a/contracts/DepositManager.sol
+++ b/contracts/DepositManager.sol
@@ -116,26 +116,31 @@ contract DepositManager is DepositCore, IDepositManager {
 
     /**
      * @notice Adds a deposit for an address to the deposit queue
-     * @param amount Number of tokens that user wants to deposit
+     * @param l1Amount Number of tokens that user wants to deposit
      * @param tokenID Type of token user is depositing
      */
     function depositFor(
         uint256 pubkeyID,
-        uint256 amount,
+        uint256 l1Amount,
         uint256 tokenID
     ) external {
-        IERC20 tokenContract = IERC20(tokenRegistry.safeGetAddress(tokenID));
+        (address addr, uint256 l2Unit) = tokenRegistry.safeGetRecord(tokenID);
+        require(
+            l1Amount % l2Unit == 0,
+            "l1Amount should be a multiple of l2Unit"
+        );
         // transfer from msg.sender to vault
         require(
-            tokenContract.allowance(msg.sender, address(this)) >= amount,
+            IERC20(addr).allowance(msg.sender, address(this)) >= l1Amount,
             "token allowance not approved"
         );
-        tokenContract.safeTransferFrom(msg.sender, vault, amount);
+        IERC20(addr).safeTransferFrom(msg.sender, vault, l1Amount);
+        uint256 l2Amount = l1Amount / l2Unit;
         // create a new state
         Types.UserState memory newState = Types.UserState(
             pubkeyID,
             tokenID,
-            amount,
+            l2Amount,
             0
         );
         // get new state hash

--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -60,15 +60,13 @@ contract Vault {
             ),
             "Vault: Commitment is not present in batch"
         );
-        IERC20 tokenContract = IERC20(
-            tokenRegistry.safeGetAddress(commitmentMP.commitment.body.tokenID)
+        (address addr, uint256 l2Unit) = tokenRegistry.safeGetRecord(
+            commitmentMP.commitment.body.tokenID
         );
         Bitmap.setClaimed(batchID, bitmap);
+        uint256 l1Amount = commitmentMP.commitment.body.amount * l2Unit;
         require(
-            tokenContract.approve(
-                msg.sender,
-                commitmentMP.commitment.body.amount
-            ),
+            IERC20(addr).approve(msg.sender, l1Amount),
             "Vault: Token approval failed"
         );
     }

--- a/contracts/test/ExampleToken.sol
+++ b/contracts/test/ExampleToken.sol
@@ -8,6 +8,6 @@ contract ExampleToken is ERC20, Ownable {
     /**
      * @dev assign totalSupply to account creating this contract */
     constructor() public ERC20("Example", "EMP") {
-        _mint(msg.sender, 10000000000000000000000);
+        _mint(msg.sender, 1000000000000000000000000000);
     }
 }

--- a/test/fast/decimal.test.ts
+++ b/test/fast/decimal.test.ts
@@ -16,10 +16,10 @@ describe("Decimal", () => {
             18690000000
         ];
         for (const value of losslessCases) {
-            const valueBN = USDT.parse(value.toString());
+            const amount = USDT.fromHumanValue(value.toString());
             assert.equal(
-                float16.round(valueBN).toString(),
-                valueBN.toString(),
+                float16.round(amount.l2Value).toString(),
+                amount.l2Value.toString(),
                 "Casted value should be the same in good cases"
             );
         }
@@ -32,9 +32,12 @@ describe("Decimal", () => {
             { input: 4095, expect: 4095 }
         ];
         for (const _case of lossyCases) {
-            const valueBN = USDT.parse(_case.input.toString());
-            const valueRounded = float16.round(valueBN);
-            assert.equal(Number(USDT.format(valueRounded)), _case.expect);
+            const value = USDT.fromHumanValue(_case.input.toString());
+            const valueRounded = float16.round(value.l2Value);
+            assert.equal(
+                Number(USDT.fromL2Value(valueRounded).humanValue),
+                _case.expect
+            );
         }
     });
 });

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -144,17 +144,17 @@ describe("Integration Test", function() {
             initialPubkeyID: 0,
             domain
         }).connect(stateTree);
-        const balance = USDT.parse("1234.0");
+        const balance = USDT.fromHumanValue("1234.0");
         const fromBlockNumber = await deployer.provider?.getBlockNumber();
         for (const user of earlyAdopters.userIterator()) {
             const pubkeyID = await accountRegistry.register(user.pubkey);
             assert.equal(pubkeyID, user.pubkeyID);
             await newToken
                 .connect(coordinator)
-                .approve(depositManager.address, balance);
+                .approve(depositManager.address, balance.l1Value);
             await depositManager
                 .connect(coordinator)
-                .depositFor(user.pubkeyID, balance, tokenID);
+                .depositFor(user.pubkeyID, balance.l1Value, tokenID);
         }
 
         const subtreeReadyEvents = await depositManager.queryFilter(
@@ -179,7 +179,7 @@ describe("Integration Test", function() {
             const batchID = await getBatchID(rollup);
             stakedBatchIDs.push(batchID);
             subgroup.createStates({
-                initialBalance: balance,
+                initialBalance: balance.l2Value,
                 tokenID,
                 zeroNonce: true
             });

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -30,10 +30,8 @@ import { getBatchID, hexToUint8Array, mineBlocks } from "../ts/utils";
 import { serialize } from "../ts/tx";
 import { ExampleToken } from "../types/ethers-contracts/ExampleToken";
 import { ExampleTokenFactory } from "../types/ethers-contracts";
-import { USDT } from "../ts/decimal";
-import { keylessDeploy } from "../ts/deployment/keylessDeployment";
+import { CommonToken } from "../ts/decimal";
 import { deployKeyless } from "../ts/deployment/deploy";
-import { deployerBytecode } from "../ts/deployment/static";
 
 // In the deploy script, we already have a TestToken registered with tokenID 0
 // We are deploying a new token with tokenID 1
@@ -144,7 +142,7 @@ describe("Integration Test", function() {
             initialPubkeyID: 0,
             domain
         }).connect(stateTree);
-        const balance = USDT.fromHumanValue("1234.0");
+        const balance = CommonToken.fromHumanValue("1234.0");
         const fromBlockNumber = await deployer.provider?.getBlockNumber();
         for (const user of earlyAdopters.userIterator()) {
             const pubkeyID = await accountRegistry.register(user.pubkey);
@@ -340,7 +338,9 @@ describe("Integration Test", function() {
             const postBalance = await newToken.balanceOf(withdrawerAddress);
             assert.equal(
                 postBalance.sub(preBalance).toString(),
-                withdrawProof.state.balance.toString()
+                CommonToken.fromL2Value(
+                    withdrawProof.state.balance
+                ).l1Value.toString()
             );
         }
     }).timeout(240000);

--- a/test/slow/rollup.create2Transfer.test.ts
+++ b/test/slow/rollup.create2Transfer.test.ts
@@ -50,7 +50,7 @@ describe("Rollup Create2Transfer", async function() {
         });
         stateTree = new StateTree(TESTING_PARAMS.MAX_DEPTH);
 
-        const initialBalance = USDT.parse("55.6");
+        const initialBalance = USDT.fromHumanValue("55.6").l2Value;
         usersWithStates
             .connect(stateTree)
             .createStates({ initialBalance, tokenID, zeroNonce: true });

--- a/test/slow/rollup.create2Transfer.test.ts
+++ b/test/slow/rollup.create2Transfer.test.ts
@@ -14,6 +14,7 @@ import {
 import { USDT } from "../../ts/decimal";
 import { hexToUint8Array } from "../../ts/utils";
 import { Group, txCreate2TransferFactory } from "../../ts/factory";
+import { deployKeyless } from "../../ts/deployment/deploy";
 
 const DOMAIN = hexToUint8Array(
     "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
@@ -57,6 +58,7 @@ describe("Rollup Create2Transfer", async function() {
 
         genesisRoot = stateTree.root;
 
+        await deployKeyless(signer, false);
         contracts = await deployAll(signer, {
             ...TESTING_PARAMS,
             GENESIS_STATE_ROOT: genesisRoot

--- a/test/slow/rollup.massMigration.test.ts
+++ b/test/slow/rollup.massMigration.test.ts
@@ -12,6 +12,7 @@ import { float16, USDT } from "../../ts/decimal";
 import { Result } from "../../ts/interfaces";
 import { expectRevert, hexToUint8Array, mineBlocks } from "../../ts/utils";
 import { Group, txMassMigrationFactory } from "../../ts/factory";
+import { deployKeyless } from "../../ts/deployment/deploy";
 
 describe("Mass Migrations", async function() {
     const tokenID = 0;
@@ -37,6 +38,7 @@ describe("Mass Migrations", async function() {
 
         genesisRoot = stateTree.root;
 
+        await deployKeyless(signer, false);
         contracts = await deployAll(signer, {
             ...TESTING_PARAMS,
             GENESIS_STATE_ROOT: genesisRoot

--- a/test/slow/rollup.massMigration.test.ts
+++ b/test/slow/rollup.massMigration.test.ts
@@ -30,7 +30,7 @@ describe("Mass Migrations", async function() {
         const [signer] = await ethers.getSigners();
         users = Group.new({ n: 32, initialStateID: 0, initialPubkeyID: 0 });
         stateTree = new StateTree(TESTING_PARAMS.MAX_DEPTH);
-        const initialBalance = USDT.parse("1000");
+        const initialBalance = USDT.fromHumanValue("1000").l2Value;
         users
             .connect(stateTree)
             .createStates({ initialBalance, tokenID, zeroNonce: false });
@@ -123,9 +123,9 @@ describe("Mass Migrations", async function() {
         const aliceState = stateTree.getState(alice.stateID).state;
         const tx = new TxMassMigration(
             alice.stateID,
-            USDT.parse("39.99"),
+            USDT.fromHumanValue("39.99").l2Value,
             1,
-            USDT.parse("0.01"),
+            USDT.fromHumanValue("0.01").l2Value,
             aliceState.nonce + 1,
             float16
         );

--- a/test/slow/rollup.massMigration.test.ts
+++ b/test/slow/rollup.massMigration.test.ts
@@ -8,7 +8,7 @@ import * as mcl from "../../ts/mcl";
 import { allContracts } from "../../ts/allContractsInterfaces";
 import { assert } from "chai";
 import { getGenesisProof, MassMigrationCommitment } from "../../ts/commitments";
-import { float16, USDT } from "../../ts/decimal";
+import { float16, CommonToken } from "../../ts/decimal";
 import { Result } from "../../ts/interfaces";
 import { expectRevert, hexToUint8Array, mineBlocks } from "../../ts/utils";
 import { Group, txMassMigrationFactory } from "../../ts/factory";
@@ -31,7 +31,8 @@ describe("Mass Migrations", async function() {
         const [signer] = await ethers.getSigners();
         users = Group.new({ n: 32, initialStateID: 0, initialPubkeyID: 0 });
         stateTree = new StateTree(TESTING_PARAMS.MAX_DEPTH);
-        const initialBalance = USDT.fromHumanValue("1000").l2Value;
+        // The example token is 18 decimals
+        const initialBalance = CommonToken.fromHumanValue("1000").l2Value;
         users
             .connect(stateTree)
             .createStates({ initialBalance, tokenID, zeroNonce: false });
@@ -125,9 +126,9 @@ describe("Mass Migrations", async function() {
         const aliceState = stateTree.getState(alice.stateID).state;
         const tx = new TxMassMigration(
             alice.stateID,
-            USDT.fromHumanValue("39.99").l2Value,
+            CommonToken.fromHumanValue("39.99").l2Value,
             1,
-            USDT.fromHumanValue("0.01").l2Value,
+            CommonToken.fromHumanValue("0.01").l2Value,
             aliceState.nonce + 1,
             float16
         );
@@ -158,7 +159,10 @@ describe("Mass Migrations", async function() {
 
         // We cheat here a little bit by sending token to the vault manually.
         // Ideally the tokens of the vault should come from the deposits
-        await exampleToken.transfer(vault.address, tx.amount);
+        await exampleToken.transfer(
+            vault.address,
+            CommonToken.fromL2Value(tx.amount).l1Value
+        );
 
         const txProcess = await withdrawManager.processWithdrawCommitment(
             batchId,

--- a/test/slow/rollup.transfer.test.ts
+++ b/test/slow/rollup.transfer.test.ts
@@ -40,7 +40,7 @@ describe("Rollup", async function() {
 
         stateTree = new StateTree(TESTING_PARAMS.MAX_DEPTH);
 
-        const initialBalance = USDT.parse("55.6");
+        const initialBalance = USDT.fromHumanValue("55.6").l2Value;
         users
             .connect(stateTree)
             .createStates({ initialBalance, tokenID, zeroNonce: true });

--- a/test/slow/rollup.transfer.test.ts
+++ b/test/slow/rollup.transfer.test.ts
@@ -11,6 +11,7 @@ import { getGenesisProof, TransferCommitment } from "../../ts/commitments";
 import { USDT } from "../../ts/decimal";
 import { hexToUint8Array } from "../../ts/utils";
 import { Group, txTransferFactory } from "../../ts/factory";
+import { deployKeyless } from "../../ts/deployment/deploy";
 
 const DOMAIN = hexToUint8Array(
     "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
@@ -47,6 +48,7 @@ describe("Rollup", async function() {
 
         genesisRoot = stateTree.root;
 
+        await deployKeyless(signer, false);
         contracts = await deployAll(signer, {
             ...TESTING_PARAMS,
             GENESIS_STATE_ROOT: genesisRoot

--- a/ts/decimal.ts
+++ b/ts/decimal.ts
@@ -55,6 +55,7 @@ class ERC20Value {
 }
 
 export const USDT = new ERC20ValueFactory(6);
+export const CommonToken = new ERC20ValueFactory(18);
 
 export class Float {
     private mantissaMax: BigNumber;

--- a/ts/factory.ts
+++ b/ts/factory.ts
@@ -148,7 +148,8 @@ export class Group {
         return states;
     }
     public createStates(options?: createStateOptions) {
-        const initialBalance = options?.initialBalance || USDT.parse("1000.0");
+        const initialBalance =
+            options?.initialBalance || USDT.fromHumanValue("1000.0").l2Value;
         const tokenID = options?.tokenID === undefined ? 5678 : options.tokenID;
         const zeroNonce = options?.zeroNonce || false;
         const arbitraryInitialNonce = 9;


### PR DESCRIPTION
### What's wrong

#475 

### How we are fixing it

- Reject token registration if erc20.decimals()> 18
- If the token has 9 + x decimals, store in state leaf x decimals
- We have a relationship `l2Amount = l1Amount // l2Unit`

Take WETH for example, it's l1Decimals is 18. We store as 9 decimals (Gwei). When deposit, we divide the l1Amount token by `10**9` to store in state leaf. When withdraw, we multiply l2Amount by `10**9` to get l1Amount token to send back.