### PR TITLE
auto label changes and change release format

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,4 @@
+contracts:
+  - contracts/**/*
+client:
+  - ts/client/**/*

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,10 +1,10 @@
 categories:
-  - title: ':sparkles: New Feature'
-    label: 'enhancement'
+  - title: ':memo: Changes in the contracts'
+    label: 'contracts'
+  - title: ':rocket: Changes in the client'
+    label: 'client'
   - title: ':bug: BugFix'
     label: 'bugfix'
-  - title: ':zap: Performance'
-    label: 'performance'
 version-resolver:
   default: minor
 prerelease: true

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,11 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@main
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
### What's wrong

The pull requests of this repo can be categorized into two labels:
- changes in the contracts
- changes in the js-client

Adding labeler and change our release note format, we reduced the manual effort to sort them in the release note. 