### PR TITLE
implement batch handler and calldata factories

### DIFF
--- a/ts/client/batchHandler.ts
+++ b/ts/client/batchHandler.ts
@@ -1,0 +1,23 @@
+import { Event } from "ethers";
+import { Rollup } from "../../types/ethers-contracts/Rollup";
+import { Batch, batchFactory } from "../commitments";
+
+export async function handleNewBatch(
+    event: Event,
+    rollup: Rollup
+): Promise<Batch> {
+    const ethTx = await event.getTransaction();
+    const data = ethTx?.data as string;
+    const txDescription = rollup.interface.parseTransaction({ data });
+    const batchID = event.args?.batchID;
+    const batchType = event.args?.batchType;
+    const accountRoot = event.args?.accountRoot;
+    const batch = batchFactory(batchType, txDescription, accountRoot);
+    const commitmentRoot = (await rollup.batches(batchID)).commitmentRoot;
+    if (batch.commitmentRoot != commitmentRoot) {
+        throw new Error(
+            `Mismatched commitmentRoot  onchain ${commitmentRoot}  parsed ${batch.commitmentRoot}`
+        );
+    }
+    return batch;
+}

--- a/ts/interfaces.ts
+++ b/ts/interfaces.ts
@@ -17,7 +17,9 @@ export interface DeploymentParameters {
 export enum Usage {
     Genesis,
     Transfer,
-    MassMigration
+    MassMigration,
+    Create2Transfer,
+    Deposit
 }
 
 export interface Hashable {


### PR DESCRIPTION
### What's wrong

To sync L2 txs in Rollup.sol, we need to parse the calldata of submitX functions.

### How we are fixing it

- listen to a new Batch event
- A factory creates a batch with respect to their batch type.
