### PR TITLE
Fix submit deposits depth bug

### DIFF
--- a/contracts/DepositManager.sol
+++ b/contracts/DepositManager.sol
@@ -11,6 +11,8 @@ interface IDepositManager {
     event DepositQueued(uint256 pubkeyID, bytes data);
     event DepositSubTreeReady(uint256 subtreeID, bytes32 subtreeRoot);
 
+    function paramMaxSubtreeDepth() external returns (uint256);
+
     function dequeueToSubmit()
         external
         returns (uint256 subtreeID, bytes32 subtreeRoot);
@@ -91,6 +93,8 @@ contract DepositCore is SubtreeQueue {
 contract DepositManager is DepositCore, IDepositManager {
     using Types for Types.UserState;
     using SafeERC20 for IERC20;
+
+    uint256 public immutable override paramMaxSubtreeDepth;
     address public immutable vault;
     // Can't be immutable yet. Since the rollup is deployed after DepositManager
     address public rollup;
@@ -110,6 +114,7 @@ contract DepositManager is DepositCore, IDepositManager {
         address _vault,
         uint256 maxSubtreeDepth
     ) public DepositCore(maxSubtreeDepth) {
+        paramMaxSubtreeDepth = maxSubtreeDepth;
         tokenRegistry = _tokenRegistry;
         vault = _vault;
     }

--- a/contracts/libs/Types.sol
+++ b/contracts/libs/Types.sol
@@ -235,7 +235,6 @@ library Types {
     }
 
     struct SubtreeVacancyProof {
-        uint256 depth;
         uint256 pathAtDepth;
         bytes32[] witness;
     }

--- a/contracts/rollup/Rollup.sol
+++ b/contracts/rollup/Rollup.sol
@@ -29,7 +29,7 @@ contract Rollup is BatchManager {
         public constant ZERO_BYTES32 = 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563;
 
     uint256 public immutable paramMaxTxsPerCommit;
-    bytes32 public immutable ZERO_HASH_AT_SUBTREE_DEPTH;
+    bytes32 public immutable zeroHashAtSubtreeDepth;
     bytes32 public immutable appID;
 
     event DepositsFinalised(
@@ -66,7 +66,7 @@ contract Rollup is BatchManager {
         create2Transfer = _create2Transfer;
 
         paramMaxTxsPerCommit = maxTxsPerCommit;
-        ZERO_HASH_AT_SUBTREE_DEPTH = MerkleTree.getRoot(
+        zeroHashAtSubtreeDepth = MerkleTree.getRoot(
             _depositManager.paramMaxSubtreeDepth()
         );
 
@@ -283,7 +283,7 @@ contract Rollup is BatchManager {
         require(
             MerkleTree.verify(
                 previous.commitment.stateRoot,
-                ZERO_HASH_AT_SUBTREE_DEPTH,
+                zeroHashAtSubtreeDepth,
                 vacant.pathAtDepth,
                 vacant.witness
             ),

--- a/contracts/rollup/Rollup.sol
+++ b/contracts/rollup/Rollup.sol
@@ -29,6 +29,7 @@ contract Rollup is BatchManager {
         public constant ZERO_BYTES32 = 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563;
 
     uint256 public immutable paramMaxTxsPerCommit;
+    bytes32 public immutable ZERO_HASH_AT_SUBTREE_DEPTH;
     bytes32 public immutable appID;
 
     event DepositsFinalised(
@@ -65,6 +66,9 @@ contract Rollup is BatchManager {
         create2Transfer = _create2Transfer;
 
         paramMaxTxsPerCommit = maxTxsPerCommit;
+        ZERO_HASH_AT_SUBTREE_DEPTH = MerkleTree.getRoot(
+            _depositManager.paramMaxSubtreeDepth()
+        );
 
         bytes32 genesisCommitment = keccak256(
             abi.encode(genesisStateRoot, ZERO_BYTES32)
@@ -279,7 +283,7 @@ contract Rollup is BatchManager {
         require(
             MerkleTree.verify(
                 previous.commitment.stateRoot,
-                MerkleTree.getRoot(vacant.depth),
+                ZERO_HASH_AT_SUBTREE_DEPTH,
                 vacant.pathAtDepth,
                 vacant.witness
             ),

--- a/contracts/test/TestRollup.sol
+++ b/contracts/test/TestRollup.sol
@@ -8,6 +8,9 @@ import { IDepositManager } from "../DepositManager.sol";
 import { Chooser } from "../proposers/Chooser.sol";
 
 contract MockDepositManager is IDepositManager {
+    // paramMaxSubtreeDepth is required by the interface, no actual use here.
+    uint256 public constant override paramMaxSubtreeDepth = 0;
+
     function dequeueToSubmit()
         external
         override

--- a/ts/stateTree.ts
+++ b/ts/stateTree.ts
@@ -129,7 +129,6 @@ export class StateTree implements StateProvider {
 
         return {
             witness: witness.nodes,
-            depth: subtreeDepth,
             pathAtDepth
         };
     }


### PR DESCRIPTION
### What's wrong

#521

### How we are fixing it?

- We set the zero hash at subtree depth when the rollup is deployed. SubmitDeposits now checks against this hash
- Remove the depth input argument from SubmitDeposits.
