### PR TITLE
add simple tokenbase

### DIFF
--- a/ts/client/tokenbase.ts
+++ b/ts/client/tokenbase.ts
@@ -1,0 +1,28 @@
+import fs from "fs";
+
+export class Tokenbase {
+    constructor(private receivers: { [key: number]: number }) {}
+
+    updateReceiver(tokenID: number, stateID: number) {
+        this.receivers[tokenID] = stateID;
+    }
+
+    getReceivableTokenIDs(): number[] {
+        return Object.keys(this.receivers).map(Number);
+    }
+
+    getReceiver(tokenID: number) {
+        const receiver = this.receivers[tokenID];
+        if (!receiver) throw new Error(`No receiver for token ${tokenID}`);
+        return receiver;
+    }
+
+    static fromConfig(path: string) {
+        const receivers = JSON.parse(fs.readFileSync(path).toString());
+        return new this(receivers);
+    }
+
+    dump(path: string) {
+        fs.writeFileSync(path, JSON.stringify(this, null, 4));
+    }
+}


### PR DESCRIPTION
### What's wrong

The proposer needs to know what tokens they are able to collect.

In the L1 protocol, the miners collect fees in units of protocol native coins. So the miner specifies coinbase or etherbase. In Hubble, however, the fees are paid in units of the token the users are transferring. So a proposer holds multiple L2 states to receive fees from different tokens.

### How we are fixing it

We create

- A config for proposers to specify which stateID they would like to receive token X.
- An API to query which tokens we are able to collect as fees. So the proposer can know what commitment they are able to pack.