### PR TITLE
revamp keyless deployer

### DIFF
--- a/scripts/keyless.ts
+++ b/scripts/keyless.ts
@@ -1,11 +1,12 @@
 import { ethers, providers } from "ethers";
 import {
     calculateAddresses,
+    deployerBytecode,
     DEPLOYER_ADDRESS,
     KEYLESS_DEPLOYMENT
 } from "../ts/deployment/static";
-import { calculateGasLimit } from "../ts/deployment/deployDeployer";
 import { deployKeyless } from "../ts/deployment/deploy";
+import { KeylessDeployer } from "../ts/deployment/keylessDeployment";
 
 const argv = require("minimist")(process.argv.slice(2), {
     string: ["url", "root"],
@@ -40,7 +41,10 @@ async function checkKeylessDeploymentSetup(
 ) {
     // Gas Limit
     if (provider) {
-        const keylessTxGasCost = await calculateGasLimit(provider);
+        const deployer = new KeylessDeployer(deployerBytecode()).connect(
+            provider
+        );
+        const keylessTxGasCost = await deployer.estimateGas();
         if (keylessTxGasCost.gt(KEYLESS_DEPLOYMENT.GAS_LIMIT)) {
             console.log(`WARNING: Gas Limit Insufficient
         expected: ${keylessTxGasCost.toString()}
@@ -62,7 +66,7 @@ async function checkKeylessDeploymentSetup(
         }
     }
 
-    const addresses = await calculateAddresses(provider);
+    const addresses = calculateAddresses();
 
     if (addresses.deployer != DEPLOYER_ADDRESS) {
         console.log(`WARNING: Bad Deployer Adress

--- a/test/fast/deployment.test.ts
+++ b/test/fast/deployment.test.ts
@@ -1,5 +1,5 @@
 import { ethers } from "hardhat";
-import { keylessDeploy } from "../../ts/deployment/keylessDeployment";
+import { KeylessDeployer } from "../../ts/deployment/keylessDeployment";
 import { SimpleStorageFactory } from "../../types/ethers-contracts/SimpleStorageFactory";
 import { BigNumber, Wallet, utils, Signer } from "ethers";
 import { assert } from "chai";
@@ -34,9 +34,9 @@ describe("Deployer", async () => {
         const gasLimit = await provider.estimateGas(
             factory.getDeployTransaction()
         );
-        // prettier-ignore
-        const result = await keylessDeploy(feeder, bytecode, gasPrice, gasLimit, verbose);
-        const simpleStorage = factory.attach(result.contractAddress);
+        const deployer = new KeylessDeployer(bytecode, gasPrice, gasLimit);
+        await deployer.fundAndDeploy(signer, verbose);
+        const simpleStorage = factory.attach(deployer.contractAddress);
         await simpleStorage.setValue(23);
         const value = await simpleStorage.getValue();
         assert.isTrue(value.eq(23));

--- a/ts/deployment/deployDeployer.ts
+++ b/ts/deployment/deployDeployer.ts
@@ -14,7 +14,12 @@ export async function deployDeployer(
 ): Promise<boolean> {
     assert(signer.provider);
     const provider = signer.provider;
-    const deployer = new KeylessDeployer(deployerBytecode()).connect(provider);
+    // Need exact GAS_PRICE and GAS_LIMIT to derive correct DEPLOYER_ADDRESS
+    const deployer = new KeylessDeployer(
+        deployerBytecode(),
+        KEYLESS_DEPLOYMENT.GAS_PRICE,
+        KEYLESS_DEPLOYMENT.GAS_LIMIT
+    ).connect(provider);
 
     if (await deployer.alreadyDeployed()) {
         logAddress(

--- a/ts/deployment/deployDeployer.ts
+++ b/ts/deployment/deployDeployer.ts
@@ -29,7 +29,6 @@ export async function deployDeployer(
         );
         return true;
     }
-    assert(KEYLESS_DEPLOYMENT.GAS_LIMIT.gte(await deployer.estimateGas()));
     assert(DEPLOYER_ADDRESS == deployer.contractAddress);
 
     const receipt = await deployer.fundAndDeploy(signer);

--- a/ts/deployment/deployDeployer.ts
+++ b/ts/deployment/deployDeployer.ts
@@ -1,8 +1,6 @@
 import { Signer } from "ethers";
-import { BigNumber } from "ethers";
 import assert from "assert";
-import { keylessDeploy, calculateKeylessDeployment } from "./keylessDeployment";
-import { Provider } from "@ethersproject/providers";
+import { KeylessDeployer } from "./keylessDeployment";
 import {
     deployerBytecode,
     DEPLOYER_ADDRESS,
@@ -10,71 +8,31 @@ import {
 } from "./static";
 import { logAddress, logDeployment } from "../../scripts/logger";
 
-export async function calculateDeployerAddress(
-    provider?: Provider
-): Promise<{ deployerAddress: string; keylessAccount: string }> {
-    let result = await calculateKeylessDeployment(
-        provider,
-        deployerBytecode(),
-        KEYLESS_DEPLOYMENT.GAS_PRICE,
-        KEYLESS_DEPLOYMENT.GAS_LIMIT,
-        false
-    );
-    return {
-        deployerAddress: result.contractAddress,
-        keylessAccount: result.keylessAccount
-    };
-}
-
-export async function calculateGasLimit(
-    provider: Provider
-): Promise<BigNumber> {
-    let result = await calculateKeylessDeployment(
-        provider,
-        deployerBytecode(),
-        KEYLESS_DEPLOYMENT.GAS_PRICE,
-        KEYLESS_DEPLOYMENT.GAS_LIMIT,
-        false
-    );
-    return result.estimatedGasCost;
-}
-
 export async function deployDeployer(
     signer: Signer,
     verbose: boolean
 ): Promise<boolean> {
     assert(signer.provider);
     const provider = signer.provider;
-    const result = await calculateKeylessDeployment(
-        provider,
-        deployerBytecode(),
-        KEYLESS_DEPLOYMENT.GAS_PRICE,
-        KEYLESS_DEPLOYMENT.GAS_LIMIT,
-        verbose
-    );
+    const deployer = new KeylessDeployer(deployerBytecode()).connect(provider);
 
-    if (result.alreadyDeployed) {
+    if (await deployer.alreadyDeployed()) {
         logAddress(
             verbose,
             "Deployer is ALREADY deployed",
-            result.contractAddress
+            deployer.contractAddress
         );
         return true;
     }
-    assert(KEYLESS_DEPLOYMENT.GAS_LIMIT.gte(result.estimatedGasCost));
-    assert(DEPLOYER_ADDRESS == result.contractAddress);
-    const _result = await keylessDeploy(
-        signer,
-        deployerBytecode(),
-        KEYLESS_DEPLOYMENT.GAS_PRICE,
-        KEYLESS_DEPLOYMENT.GAS_LIMIT,
-        verbose
-    );
+    assert(KEYLESS_DEPLOYMENT.GAS_LIMIT.gte(await deployer.estimateGas()));
+    assert(DEPLOYER_ADDRESS == deployer.contractAddress);
+
+    const receipt = await deployer.fundAndDeploy(signer);
     logDeployment(
         verbose,
         "Deployed: Deployer",
-        _result.receipt.transactionHash,
-        _result.contractAddress
+        receipt.transactionHash,
+        deployer.contractAddress
     );
     return true;
 }

--- a/ts/deployment/static.ts
+++ b/ts/deployment/static.ts
@@ -1,8 +1,7 @@
 import { BigNumber, utils } from "ethers";
-import { calculateDeployerAddress } from "./deployDeployer";
-import { Provider } from "@ethersproject/providers";
 import { ProxyFactory } from "../../types/ethers-contracts/ProxyFactory";
 import { DeployerFactory } from "../../types/ethers-contracts/DeployerFactory";
+import { KeylessDeployer } from "./keylessDeployment";
 
 export const PROXY_BYTECODE = proxyBytecode();
 export const PROXY_CODE_HASH = utils.keccak256(PROXY_BYTECODE);
@@ -30,19 +29,16 @@ export interface StaticAdresses {
     bnPairingCostEstimator: string;
 }
 
-export async function calculateAddresses(
-    provider?: Provider
-): Promise<StaticAdresses> {
-    const deployerResult = await calculateDeployerAddress(provider);
-    const deployer = deployerResult.deployerAddress;
-    const keyless = deployerResult.keylessAccount;
+export function calculateAddresses(): StaticAdresses {
+    const deployer = new KeylessDeployer(deployerBytecode());
+
     const bnPairingCostEstimator = calculateAddress(
-        deployer,
+        deployer.contractAddress,
         SALT.PAIRING_GAS_ESTIMATOR
     );
     const addresses = {
-        keyless,
-        deployer,
+        deployer: deployer.contractAddress,
+        keyless: deployer.keylessAccount,
         bnPairingCostEstimator
     };
     return addresses;


### PR DESCRIPTION
### What's wrong

The only parameter that calculateKeylessDeployment really needs is "bytecode". Other parameters like providers, gas price, gas limit, and verbose can be passed on-demand or assigned with a default value.

We run calculateKeylessDeployment multiple times to get some fields in the output. These fields include contractAddress,
 keylessAccount, estimatedGasCost, alreadyDeployed, and rawDeplotmentTx. The contractAddress, keylessAccount, and rawDeplotmentTx can be derived when we have the information of bytecode, gas price, and gas limit. But to get estimatedGasCost and alreadyDeployed we need to connect a provider.

### How can we fix it

- We create a KeylessDeployer class that holds bytecode, contractAddress, keylessAccount, and rawDeplotmentTx.  
- Connected with a provider, KeylessDeployer can 
  - estimatedGasCost when we really need the number 
  - or tell us if the contract is already deployed