### PR TITLE
Move dependencies to a core api

### DIFF
--- a/test/client/integration.test.ts
+++ b/test/client/integration.test.ts
@@ -1,25 +1,26 @@
 import { arrayify } from "@ethersproject/bytes";
 import { assert } from "chai";
+import { providers } from "ethers";
 import { ethers } from "hardhat";
-import { buildStrategies } from "../../ts/client/contexts";
-import { DepositPool } from "../../ts/client/features/deposit";
+import { CoreAPI } from "../../ts/client/coreAPI";
 import {
     SimulatorPool,
     TransferPackingCommand
 } from "../../ts/client/features/transfer";
-import { SyncedPoint } from "../../ts/client/node";
 import { SyncerService } from "../../ts/client/services/syncer";
 import { PRODUCTION_PARAMS } from "../../ts/constants";
 import { deployAll } from "../../ts/deploy";
 import { deployKeyless } from "../../ts/deployment/deploy";
 import { Group, storageManagerFactory } from "../../ts/factory";
+import { Genesis } from "../../ts/genesis";
 import * as mcl from "../../ts/mcl";
 
 describe("Client Integration", function() {
     it("run", async function() {
         await mcl.init();
         const [signer] = await ethers.getSigners();
-        const genesisEth1Block = (await signer.provider?.getBlockNumber()) as number;
+        const provider = signer.provider as providers.Provider;
+        const genesisEth1Block = await provider.getBlockNumber();
         await deployKeyless(signer, false);
         const group = Group.new({ n: 32 });
         const storagePacker = await storageManagerFactory(group);
@@ -35,32 +36,26 @@ describe("Client Integration", function() {
 
         const simPool = new SimulatorPool(group, storagePacker.state);
         await simPool.setTokenID();
+        const genesis = await Genesis.fromContracts(
+            contracts,
+            parameters,
+            genesisEth1Block
+        );
+
+        const apiPacker = CoreAPI.new(storagePacker, genesis, provider, signer);
+        const apiSyncer = CoreAPI.new(storageSyncer, genesis, provider, signer);
 
         const packingCommand = new TransferPackingCommand(
-            parameters,
-            storagePacker,
+            apiPacker.parameters,
+            apiPacker.l2Storage,
             simPool,
-            contracts.rollup
+            apiPacker.rollup
         );
         for (let i = 0; i < 10; i++) {
             await packingCommand.packAndSubmit();
         }
 
-        const depositPool = new DepositPool(
-            parameters.MAX_DEPOSIT_SUBTREE_DEPTH
-        );
-        const strategies = buildStrategies(
-            contracts,
-            storageSyncer,
-            parameters,
-            depositPool
-        );
-        const syncpoint = new SyncedPoint(genesisEth1Block, 0);
-        const syncService = new SyncerService(
-            contracts.rollup,
-            syncpoint,
-            strategies
-        );
+        const syncService = new SyncerService(apiSyncer);
         await syncService.initialSync();
         assert.equal(storageSyncer.state.root, storagePacker.state.root);
     }).timeout(300000);

--- a/ts/client/contexts.ts
+++ b/ts/client/contexts.ts
@@ -1,31 +1,23 @@
 import { Event } from "@ethersproject/contracts";
-import { allContracts } from "../allContractsInterfaces";
-import { DeploymentParameters, Usage } from "../interfaces";
-import { DepositHandlingStrategy, DepositPool } from "./features/deposit";
+import { Usage } from "../interfaces";
+import { CoreAPI } from "./coreAPI";
+import { DepositHandlingStrategy } from "./features/deposit";
 import { GenesisHandlingStrategy } from "./features/genesis";
 import { Batch, BatchHandlingStrategy } from "./features/interface";
 import { TransferHandlingStrategy } from "./features/transfer";
-import { StorageManager } from "./storageEngine";
 
-export function buildStrategies(
-    contracts: allContracts,
-    storageManager: StorageManager,
-    parameters: DeploymentParameters,
-    depositPool: DepositPool
-) {
-    const genesisStrategy = new GenesisHandlingStrategy(
-        storageManager.state.root
-    );
+export function buildStrategies(api: CoreAPI) {
+    const genesisStrategy = new GenesisHandlingStrategy(api.getGenesisRoot());
     const transferStrategy = new TransferHandlingStrategy(
-        contracts.rollup,
-        storageManager,
-        parameters
+        api.contracts.rollup,
+        api.l2Storage,
+        api.parameters
     );
     const depositStrategy = new DepositHandlingStrategy(
-        contracts.rollup,
-        storageManager,
-        parameters,
-        depositPool
+        api.contracts.rollup,
+        api.l2Storage,
+        api.parameters,
+        api.depositPool
     );
     const strategies: { [key: string]: BatchHandlingStrategy } = {};
     strategies[Usage.Genesis] = genesisStrategy;

--- a/ts/client/coreAPI.ts
+++ b/ts/client/coreAPI.ts
@@ -1,0 +1,55 @@
+import { Genesis } from "../genesis";
+import { Pubkey } from "../pubkey";
+import { State } from "../state";
+import { DepositPool } from "./features/deposit";
+import { StorageManager } from "./storageEngine";
+import { Signer } from "ethers";
+import { allContracts } from "../allContractsInterfaces";
+
+export interface ICoreAPI {
+    getState(stateID: number): Promise<State>;
+    updateState(stateID: number, state: State): Promise<void>;
+    getPubkey(pubkeyID: number): Promise<Pubkey>;
+    updatePubkey(pubkeyID: number, pubkey: Pubkey): Promise<void>;
+}
+
+export class CoreAPI implements ICoreAPI {
+    private constructor(
+        public readonly l2Storage: StorageManager,
+        private readonly genesis: Genesis,
+        public readonly depositPool: DepositPool,
+        public readonly contracts: allContracts
+    ) {}
+
+    static new(l2Storage: StorageManager, genesis: Genesis, signer: Signer) {
+        const depositPool = new DepositPool(
+            genesis.parameters.MAX_DEPOSIT_SUBTREE_DEPTH
+        );
+        const contracts = genesis.getContracts(signer);
+        return new this(l2Storage, genesis, depositPool, contracts);
+    }
+
+    get parameters() {
+        return this.genesis.parameters;
+    }
+
+    getGenesisRoot() {
+        return this.genesis.parameters.GENESIS_STATE_ROOT as string;
+    }
+
+    async getState(stateID: number): Promise<State> {
+        return await this.l2Storage.state.get(stateID);
+    }
+
+    async updateState(stateID: number, state: State): Promise<void> {
+        await this.l2Storage.state.update(stateID, state);
+        await this.l2Storage.state.commit();
+    }
+    async getPubkey(pubkeyID: number): Promise<Pubkey> {
+        return this.l2Storage.pubkey.get(pubkeyID);
+    }
+    async updatePubkey(pubkeyID: number, pubkey: Pubkey): Promise<void> {
+        await this.l2Storage.pubkey.update(pubkeyID, pubkey);
+        await this.l2Storage.pubkey.commit();
+    }
+}

--- a/ts/client/coreAPI.ts
+++ b/ts/client/coreAPI.ts
@@ -3,10 +3,42 @@ import { Pubkey } from "../pubkey";
 import { State } from "../state";
 import { DepositPool } from "./features/deposit";
 import { StorageManager } from "./storageEngine";
-import { Signer } from "ethers";
+import { providers, Signer } from "ethers";
 import { allContracts } from "../allContractsInterfaces";
 
+export class SyncedPoint {
+    constructor(public blockNumber: number, public batchID: number) {}
+
+    private validateBlockNumber(blockNumber: number) {
+        if (blockNumber < this.blockNumber)
+            throw new Error(
+                `new block number is smaller  old ${this.blockNumber}  new ${blockNumber}`
+            );
+    }
+    private validateBatchID(batchID: number) {
+        if (batchID < this.batchID)
+            throw new Error(
+                `new batchID is smaller  old ${this.batchID}  new ${batchID}`
+            );
+    }
+
+    update(blockNumber: number, batchID: number) {
+        this.validateBlockNumber(blockNumber);
+        this.validateBatchID(batchID);
+
+        this.blockNumber = blockNumber;
+        this.batchID = batchID;
+    }
+
+    bump(blockNumber: number) {
+        this.validateBlockNumber(blockNumber);
+        this.batchID++;
+        this.blockNumber = blockNumber;
+    }
+}
+
 export interface ICoreAPI {
+    getlatestBatchID(): Promise<number>;
     getState(stateID: number): Promise<State>;
     updateState(stateID: number, state: State): Promise<void>;
     getPubkey(pubkeyID: number): Promise<Pubkey>;
@@ -18,15 +50,37 @@ export class CoreAPI implements ICoreAPI {
         public readonly l2Storage: StorageManager,
         private readonly genesis: Genesis,
         public readonly depositPool: DepositPool,
-        public readonly contracts: allContracts
+        private readonly provider: providers.Provider,
+        public readonly contracts: allContracts,
+        public readonly syncpoint: SyncedPoint
     ) {}
 
-    static new(l2Storage: StorageManager, genesis: Genesis, signer: Signer) {
+    static new(
+        l2Storage: StorageManager,
+        genesis: Genesis,
+        provider: providers.Provider,
+        signer: Signer
+    ) {
         const depositPool = new DepositPool(
             genesis.parameters.MAX_DEPOSIT_SUBTREE_DEPTH
         );
         const contracts = genesis.getContracts(signer);
-        return new this(l2Storage, genesis, depositPool, contracts);
+        const syncedPoint = new SyncedPoint(
+            genesis.auxiliary.genesisEth1Block,
+            0
+        );
+        return new this(
+            l2Storage,
+            genesis,
+            depositPool,
+            provider,
+            contracts,
+            syncedPoint
+        );
+    }
+
+    get rollup() {
+        return this.contracts.rollup;
     }
 
     get parameters() {
@@ -35,6 +89,12 @@ export class CoreAPI implements ICoreAPI {
 
     getGenesisRoot() {
         return this.genesis.parameters.GENESIS_STATE_ROOT as string;
+    }
+    async getBlockNumber() {
+        return await this.provider.getBlockNumber();
+    }
+    async getlatestBatchID() {
+        return Number(await this.rollup.nextBatchID()) - 1;
     }
 
     async getState(stateID: number): Promise<State> {

--- a/ts/client/node.ts
+++ b/ts/client/node.ts
@@ -6,7 +6,6 @@ import { Bidder } from "./services/bidder";
 import { ethers } from "ethers";
 import { SyncerService } from "./services/syncer";
 import { Genesis } from "../genesis";
-import { DepositPool } from "./features/deposit";
 import { buildStrategies } from "./contexts";
 import { Packer } from "./services/packer";
 import { TransferPool } from "./features/transfer";
@@ -14,6 +13,7 @@ import { Provider } from "@ethersproject/providers";
 import { BurnAuctionWrapper } from "../burnAuction";
 import { EventEmitter } from "events";
 import { RPC } from "./services/rpc";
+import { CoreAPI } from "./coreAPI";
 
 class NodeEmitter extends EventEmitter {}
 
@@ -67,17 +67,10 @@ export class HubbleNode {
         const storageManager = await storageManagerFactory(group, {
             stateTreeDepth: parameters.MAX_DEPTH
         });
+        const api = CoreAPI.new(storageManager, genesis, signer);
         const syncedPoint = new SyncedPoint(auxiliary.genesisEth1Block, 0);
 
-        const depositPool = new DepositPool(
-            parameters.MAX_DEPOSIT_SUBTREE_DEPTH
-        );
-        const strategies = buildStrategies(
-            contracts,
-            storageManager,
-            parameters,
-            depositPool
-        );
+        const strategies = buildStrategies(api);
 
         const feeReceiver = group.getUser(0).stateID;
         const tokenID = (await storageManager.state.get(feeReceiver)).tokenID;


### PR DESCRIPTION
### What's wrong

We've been passing around objects in different services. It's bothersome to keep tracks of them

### How we are fixing it

Use a monolithic core API and build all the objects there.

