### PR TITLE
Update prettier-plugin-solidity

### DIFF
--- a/contracts/DepositManager.sol
+++ b/contracts/DepositManager.sol
@@ -146,12 +146,8 @@ contract DepositManager is DepositCore, IDepositManager {
         IERC20(addr).safeTransferFrom(msg.sender, vault, l1Amount);
         uint256 l2Amount = l1Amount / l2Unit;
         // create a new state
-        Types.UserState memory newState = Types.UserState(
-            pubkeyID,
-            tokenID,
-            l2Amount,
-            0
-        );
+        Types.UserState memory newState =
+            Types.UserState(pubkeyID, tokenID, l2Amount, 0);
         // get new state hash
         bytes memory encodedState = newState.encode();
         emit DepositQueued(pubkeyID, encodedState);

--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -61,9 +61,8 @@ contract Vault {
             ),
             "Vault: Commitment is not present in batch"
         );
-        (address addr, uint256 l2Unit) = tokenRegistry.safeGetRecord(
-            commitmentMP.commitment.body.tokenID
-        );
+        (address addr, uint256 l2Unit) =
+            tokenRegistry.safeGetRecord(commitmentMP.commitment.body.tokenID);
         Bitmap.setClaimed(batchID, bitmap);
         uint256 l1Amount = commitmentMP.commitment.body.amount * l2Unit;
         require(

--- a/contracts/WithdrawManager.sol
+++ b/contracts/WithdrawManager.sol
@@ -40,9 +40,8 @@ contract WithdrawManager {
         Types.MMCommitmentInclusionProof memory commitmentMP
     ) public {
         vault.requestApproval(batchID, commitmentMP);
-        (address addr, uint256 l2Unit) = tokenRegistry.safeGetRecord(
-            commitmentMP.commitment.body.tokenID
-        );
+        (address addr, uint256 l2Unit) =
+            tokenRegistry.safeGetRecord(commitmentMP.commitment.body.tokenID);
         processed[commitmentMP.commitment.body.withdrawRoot] = commitmentMP
             .commitment
             .body
@@ -96,9 +95,8 @@ contract WithdrawManager {
         );
         require(callSuccess, "WithdrawManager: Precompile call failed");
         require(checkSuccess, "WithdrawManager: Bad signature");
-        (address addr, uint256 l2Unit) = tokenRegistry.safeGetRecord(
-            withdrawal.state.tokenID
-        );
+        (address addr, uint256 l2Unit) =
+            tokenRegistry.safeGetRecord(withdrawal.state.tokenID);
         Bitmap.setClaimed(withdrawal.state.pubkeyID, bitmap[withdrawRoot]);
         uint256 l1Amount = withdrawal.state.balance * l2Unit;
         // transfer tokens from vault

--- a/contracts/client/FrontendCreate2Transfer.sol
+++ b/contracts/client/FrontendCreate2Transfer.sol
@@ -50,12 +50,11 @@ contract FrontendCreate2Transfer {
         pure
         returns (bytes memory)
     {
-        Tx.Create2Transfer[] memory txTxs = new Tx.Create2Transfer[](
-            encodedTxs.length
-        );
+        Tx.Create2Transfer[] memory txTxs =
+            new Tx.Create2Transfer[](encodedTxs.length);
         for (uint256 i = 0; i < txTxs.length; i++) {
-            Offchain.Create2Transfer memory _tx = Offchain
-                .decodeCreate2Transfer(encodedTxs[i]);
+            Offchain.Create2Transfer memory _tx =
+                Offchain.decodeCreate2Transfer(encodedTxs[i]);
             txTxs[i] = Tx.Create2Transfer(
                 _tx.fromIndex,
                 _tx.toIndex,
@@ -85,8 +84,8 @@ contract FrontendCreate2Transfer {
         pure
         returns (bytes memory)
     {
-        Offchain.Create2TransferWithPub memory _tx = Offchain
-            .decodeCreate2TransferWithPub(encodedTxWithPub);
+        Offchain.Create2TransferWithPub memory _tx =
+            Offchain.decodeCreate2TransferWithPub(encodedTxWithPub);
         Tx.Create2Transfer memory txTx;
         txTx.fromIndex = _tx.fromIndex;
         txTx.amount = _tx.amount;
@@ -101,23 +100,20 @@ contract FrontendCreate2Transfer {
         uint256[4] calldata pubkeyReceiver,
         bytes32 domain
     ) external view returns (bool) {
-        Offchain.Create2Transfer memory _tx = Offchain.decodeCreate2Transfer(
-            encodedTx
-        );
+        Offchain.Create2Transfer memory _tx =
+            Offchain.decodeCreate2Transfer(encodedTx);
         Tx.encodeDecimal(_tx.amount);
         Tx.encodeDecimal(_tx.fee);
-        Tx.Create2Transfer memory txTx = Tx.Create2Transfer(
-            _tx.fromIndex,
-            _tx.toIndex,
-            _tx.toPubkeyID,
-            _tx.amount,
-            _tx.fee
-        );
-        bytes memory txMsg = Tx.create2TransferMessageOf(
-            txTx,
-            _tx.nonce,
-            pubkeyReceiver
-        );
+        Tx.Create2Transfer memory txTx =
+            Tx.Create2Transfer(
+                _tx.fromIndex,
+                _tx.toIndex,
+                _tx.toPubkeyID,
+                _tx.amount,
+                _tx.fee
+            );
+        bytes memory txMsg =
+            Tx.create2TransferMessageOf(txTx, _tx.nonce, pubkeyReceiver);
 
         bool callSuccess;
         bool checkSuccess;
@@ -144,9 +140,8 @@ contract FrontendCreate2Transfer {
             Types.Result result
         )
     {
-        Offchain.Create2Transfer memory _tx = Offchain.decodeCreate2Transfer(
-            encodedTx
-        );
+        Offchain.Create2Transfer memory _tx =
+            Offchain.decodeCreate2Transfer(encodedTx);
         Types.UserState memory sender = Types.decodeState(senderEncoded);
         uint256 tokenID = sender.tokenID;
         (sender, result) = Transition.validateAndApplySender(
@@ -172,15 +167,16 @@ contract FrontendCreate2Transfer {
         Types.StateMerkleProof memory from,
         Types.StateMerkleProof memory to
     ) public pure returns (bytes32 newRoot, Types.Result result) {
-        Offchain.Create2Transfer memory offchainTx = Offchain
-            .decodeCreate2Transfer(encodedTx);
-        Tx.Create2Transfer memory _tx = Tx.Create2Transfer(
-            offchainTx.fromIndex,
-            offchainTx.toIndex,
-            offchainTx.toPubkeyID,
-            offchainTx.amount,
-            offchainTx.fee
-        );
+        Offchain.Create2Transfer memory offchainTx =
+            Offchain.decodeCreate2Transfer(encodedTx);
+        Tx.Create2Transfer memory _tx =
+            Tx.Create2Transfer(
+                offchainTx.fromIndex,
+                offchainTx.toIndex,
+                offchainTx.toPubkeyID,
+                offchainTx.amount,
+                offchainTx.fee
+            );
         return
             Transition.processCreate2Transfer(
                 stateRoot,
@@ -199,13 +195,14 @@ contract FrontendCreate2Transfer {
         bytes32 domain,
         bytes memory txs
     ) public view returns (Types.Result) {
-        Types.AuthCommon memory common = Types.AuthCommon({
-            signature: signature,
-            stateRoot: stateRoot,
-            accountRoot: accountRoot,
-            domain: domain,
-            txs: txs
-        });
+        Types.AuthCommon memory common =
+            Types.AuthCommon({
+                signature: signature,
+                stateRoot: stateRoot,
+                accountRoot: accountRoot,
+                domain: domain,
+                txs: txs
+            });
 
         return Authenticity.verifyCreate2Transfer(common, proof);
     }

--- a/contracts/client/FrontendMassMigration.sol
+++ b/contracts/client/FrontendMassMigration.sol
@@ -34,13 +34,11 @@ contract FrontendMassMigration {
         pure
         returns (bytes memory)
     {
-        Tx.MassMigration[] memory txTxs = new Tx.MassMigration[](
-            encodedTxs.length
-        );
+        Tx.MassMigration[] memory txTxs =
+            new Tx.MassMigration[](encodedTxs.length);
         for (uint256 i = 0; i < txTxs.length; i++) {
-            Offchain.MassMigration memory _tx = Offchain.decodeMassMigration(
-                encodedTxs[i]
-            );
+            Offchain.MassMigration memory _tx =
+                Offchain.decodeMassMigration(encodedTxs[i]);
             txTxs[i] = Tx.MassMigration(_tx.fromIndex, _tx.amount, _tx.fee);
         }
         return Tx.serialize(txTxs);
@@ -64,14 +62,10 @@ contract FrontendMassMigration {
         pure
         returns (bytes memory)
     {
-        Offchain.MassMigration memory _tx = Offchain.decodeMassMigration(
-            encodedTx
-        );
-        Tx.MassMigration memory txTx = Tx.MassMigration(
-            _tx.fromIndex,
-            _tx.amount,
-            _tx.fee
-        );
+        Offchain.MassMigration memory _tx =
+            Offchain.decodeMassMigration(encodedTx);
+        Tx.MassMigration memory txTx =
+            Tx.MassMigration(_tx.fromIndex, _tx.amount, _tx.fee);
         return Tx.massMigrationMessageOf(txTx, _tx.nonce, _tx.spokeID);
     }
 
@@ -81,21 +75,14 @@ contract FrontendMassMigration {
         uint256[4] calldata pubkey,
         bytes32 domain
     ) external view returns (bool) {
-        Offchain.MassMigration memory _tx = Offchain.decodeMassMigration(
-            encodedTx
-        );
+        Offchain.MassMigration memory _tx =
+            Offchain.decodeMassMigration(encodedTx);
         Tx.encodeDecimal(_tx.amount);
         Tx.encodeDecimal(_tx.fee);
-        Tx.MassMigration memory txTx = Tx.MassMigration(
-            _tx.fromIndex,
-            _tx.amount,
-            _tx.fee
-        );
-        bytes memory txMsg = Tx.massMigrationMessageOf(
-            txTx,
-            _tx.nonce,
-            _tx.spokeID
-        );
+        Tx.MassMigration memory txTx =
+            Tx.MassMigration(_tx.fromIndex, _tx.amount, _tx.fee);
+        bytes memory txMsg =
+            Tx.massMigrationMessageOf(txTx, _tx.nonce, _tx.spokeID);
 
         bool callSuccess;
         bool checkSuccess;
@@ -122,9 +109,8 @@ contract FrontendMassMigration {
             Types.Result result
         )
     {
-        Offchain.MassMigration memory _tx = Offchain.decodeMassMigration(
-            encodedTx
-        );
+        Offchain.MassMigration memory _tx =
+            Offchain.decodeMassMigration(encodedTx);
         Types.UserState memory sender = Types.decodeState(senderEncoded);
         uint256 tokenID = sender.tokenID;
         (sender, result) = Transition.validateAndApplySender(
@@ -156,14 +142,14 @@ contract FrontendMassMigration {
             Types.Result result
         )
     {
-        Offchain.MassMigration memory offchainTx = Offchain.decodeMassMigration(
-            encodedTx
-        );
-        Tx.MassMigration memory _tx = Tx.MassMigration(
-            offchainTx.fromIndex,
-            offchainTx.amount,
-            offchainTx.fee
-        );
+        Offchain.MassMigration memory offchainTx =
+            Offchain.decodeMassMigration(encodedTx);
+        Tx.MassMigration memory _tx =
+            Tx.MassMigration(
+                offchainTx.fromIndex,
+                offchainTx.amount,
+                offchainTx.fee
+            );
         return Transition.processMassMigration(stateRoot, _tx, tokenID, from);
     }
 
@@ -176,13 +162,14 @@ contract FrontendMassMigration {
         uint256 spokeID,
         bytes memory txs
     ) public view returns (Types.Result) {
-        Types.AuthCommon memory common = Types.AuthCommon({
-            signature: signature,
-            stateRoot: stateRoot,
-            accountRoot: accountRoot,
-            domain: domain,
-            txs: txs
-        });
+        Types.AuthCommon memory common =
+            Types.AuthCommon({
+                signature: signature,
+                stateRoot: stateRoot,
+                accountRoot: accountRoot,
+                domain: domain,
+                txs: txs
+            });
         return Authenticity.verifyMassMigration(common, proof, spokeID);
     }
 }

--- a/contracts/client/FrontendTransfer.sol
+++ b/contracts/client/FrontendTransfer.sol
@@ -36,9 +36,8 @@ contract FrontendTransfer {
     {
         Tx.Transfer[] memory txTxs = new Tx.Transfer[](encodedTxs.length);
         for (uint256 i = 0; i < txTxs.length; i++) {
-            Offchain.Transfer memory _tx = Offchain.decodeTransfer(
-                encodedTxs[i]
-            );
+            Offchain.Transfer memory _tx =
+                Offchain.decodeTransfer(encodedTxs[i]);
             txTxs[i] = Tx.Transfer(
                 _tx.fromIndex,
                 _tx.toIndex,
@@ -68,12 +67,8 @@ contract FrontendTransfer {
         returns (bytes memory)
     {
         Offchain.Transfer memory _tx = Offchain.decodeTransfer(encodedTx);
-        Tx.Transfer memory txTx = Tx.Transfer(
-            _tx.fromIndex,
-            _tx.toIndex,
-            _tx.amount,
-            _tx.fee
-        );
+        Tx.Transfer memory txTx =
+            Tx.Transfer(_tx.fromIndex, _tx.toIndex, _tx.amount, _tx.fee);
         return Tx.transferMessageOf(txTx, _tx.nonce);
     }
 
@@ -86,12 +81,8 @@ contract FrontendTransfer {
         Offchain.Transfer memory _tx = Offchain.decodeTransfer(encodedTx);
         Tx.encodeDecimal(_tx.amount);
         Tx.encodeDecimal(_tx.fee);
-        Tx.Transfer memory txTx = Tx.Transfer(
-            _tx.fromIndex,
-            _tx.toIndex,
-            _tx.amount,
-            _tx.fee
-        );
+        Tx.Transfer memory txTx =
+            Tx.Transfer(_tx.fromIndex, _tx.toIndex, _tx.amount, _tx.fee);
         bytes memory txMsg = Tx.transferMessageOf(txTx, _tx.nonce);
 
         bool callSuccess;
@@ -146,15 +137,15 @@ contract FrontendTransfer {
         Types.StateMerkleProof memory from,
         Types.StateMerkleProof memory to
     ) public pure returns (bytes32 newRoot, Types.Result result) {
-        Offchain.Transfer memory offchainTx = Offchain.decodeTransfer(
-            encodedTx
-        );
-        Tx.Transfer memory _tx = Tx.Transfer(
-            offchainTx.fromIndex,
-            offchainTx.toIndex,
-            offchainTx.amount,
-            offchainTx.fee
-        );
+        Offchain.Transfer memory offchainTx =
+            Offchain.decodeTransfer(encodedTx);
+        Tx.Transfer memory _tx =
+            Tx.Transfer(
+                offchainTx.fromIndex,
+                offchainTx.toIndex,
+                offchainTx.amount,
+                offchainTx.fee
+            );
         return Transition.processTransfer(stateRoot, _tx, tokenID, from, to);
     }
 
@@ -166,13 +157,14 @@ contract FrontendTransfer {
         bytes32 domain,
         bytes memory txs
     ) public view returns (Types.Result) {
-        Types.AuthCommon memory common = Types.AuthCommon({
-            signature: signature,
-            stateRoot: stateRoot,
-            accountRoot: accountRoot,
-            domain: domain,
-            txs: txs
-        });
+        Types.AuthCommon memory common =
+            Types.AuthCommon({
+                signature: signature,
+                stateRoot: stateRoot,
+                accountRoot: accountRoot,
+                domain: domain,
+                txs: txs
+            });
         return Authenticity.verifyTransfer(common, proof);
     }
 }

--- a/contracts/deployment/Deployer.sol
+++ b/contracts/deployment/Deployer.sol
@@ -56,9 +56,8 @@ contract Deployer {
         // for accounts without code, i.e. `keccak256('')`
         bytes32 codehash;
 
-
-            bytes32 accountHash
-         = 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470;
+        bytes32 accountHash =
+            0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470;
         // solhint-disable-next-line no-inline-assembly
         assembly {
             codehash := extcodehash(account)

--- a/contracts/deployment/Proxy.sol
+++ b/contracts/deployment/Proxy.sol
@@ -3,8 +3,8 @@ pragma solidity ^0.6.12;
 
 contract Proxy {
     // IMPLEMENTATION_SLOT is an arbitrary random hex
-    bytes32
-        private constant IMPLEMENTATION_SLOT = 0x7050c9e0f4ca769c69bd3a8ef740bc37934f8e2c036e5a723fd8ee048ed3f8c3;
+    bytes32 private constant IMPLEMENTATION_SLOT =
+        0x7050c9e0f4ca769c69bd3a8ef740bc37934f8e2c036e5a723fd8ee048ed3f8c3;
 
     fallback() external payable {
         _fallback();

--- a/contracts/libs/Authenticity.sol
+++ b/contracts/libs/Authenticity.sol
@@ -193,11 +193,12 @@ library Authenticity {
                 if (senders[k] == safeIndex) nonce--;
             }
             senders[j] = safeIndex;
-            bytes memory txMsg = Tx.create2TransferMessageOf(
-                _tx,
-                nonce,
-                proof.pubkeysReceiver[i]
-            );
+            bytes memory txMsg =
+                Tx.create2TransferMessageOf(
+                    _tx,
+                    nonce,
+                    proof.pubkeysReceiver[i]
+                );
 
             messages[i] = BLS.hashToPoint(common.domain, txMsg);
         }

--- a/contracts/libs/BLS.sol
+++ b/contracts/libs/BLS.sol
@@ -39,33 +39,34 @@ library BLS {
     uint256 private constant MASK24 = 0xffffffffffffffffffffffffffffffffffffffffffffffff;
 
     // estimator address
-    address
-        private constant COST_ESTIMATOR_ADDRESS = 0x079d8077C465BD0BF0FC502aD2B846757e415661;
+    address private constant COST_ESTIMATOR_ADDRESS =
+        0x079d8077C465BD0BF0FC502aD2B846757e415661;
 
     function verifySingle(
         uint256[2] memory signature,
         uint256[4] memory pubkey,
         uint256[2] memory message
     ) internal view returns (bool, bool) {
-        uint256[12] memory input = [
-            signature[0],
-            signature[1],
-            N_G2_X1,
-            N_G2_X0,
-            N_G2_Y1,
-            N_G2_Y0,
-            message[0],
-            message[1],
-            pubkey[1],
-            pubkey[0],
-            pubkey[3],
-            pubkey[2]
-        ];
+        uint256[12] memory input =
+            [
+                signature[0],
+                signature[1],
+                N_G2_X1,
+                N_G2_X0,
+                N_G2_Y1,
+                N_G2_Y0,
+                message[0],
+                message[1],
+                pubkey[1],
+                pubkey[0],
+                pubkey[3],
+                pubkey[2]
+            ];
         uint256[1] memory out;
-        uint256 precompileGasCost = BNPairingPrecompileCostEstimator(
-            COST_ESTIMATOR_ADDRESS
-        )
-            .getGasCost(2);
+        uint256 precompileGasCost =
+            BNPairingPrecompileCostEstimator(COST_ESTIMATOR_ADDRESS).getGasCost(
+                2
+            );
         bool callSuccess;
         // solium-disable-next-line security/no-inline-assembly
         assembly {

--- a/contracts/libs/BNPairingPrecompileCostEstimator.sol
+++ b/contracts/libs/BNPairingPrecompileCostEstimator.sol
@@ -67,20 +67,21 @@ contract BNPairingPrecompileCostEstimator {
     }
 
     function _gasCost2Pair() internal view returns (uint256) {
-        uint256[12] memory input = [
-            G1_X,
-            G1_Y,
-            G2_X1,
-            G2_X0,
-            G2_Y1,
-            G2_Y0,
-            G1_X,
-            G1_Y,
-            G2_X1,
-            G2_X0,
-            N_G2_Y1,
-            N_G2_Y0
-        ];
+        uint256[12] memory input =
+            [
+                G1_X,
+                G1_Y,
+                G2_X1,
+                G2_X0,
+                G2_Y1,
+                G2_Y0,
+                G1_X,
+                G1_Y,
+                G2_X1,
+                G2_X0,
+                N_G2_Y1,
+                N_G2_Y0
+            ];
         uint256[1] memory out;
         bool callSuccess;
         uint256 suppliedGas = gasleft() - 2000;

--- a/contracts/libs/MerkleTree.sol
+++ b/contracts/libs/MerkleTree.sol
@@ -36,50 +36,126 @@ library MerkleTree {
 
     function getRoot(uint256 level) internal pure returns (bytes32) {
         bytes32[32] memory hashes;
-        hashes[0] = 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563;
-        hashes[1] = 0x633dc4d7da7256660a892f8f1604a44b5432649cc8ec5cb3ced4c4e6ac94dd1d;
-        hashes[2] = 0x890740a8eb06ce9be422cb8da5cdafc2b58c0a5e24036c578de2a433c828ff7d;
-        hashes[3] = 0x3b8ec09e026fdc305365dfc94e189a81b38c7597b3d941c279f042e8206e0bd8;
-        hashes[4] = 0xecd50eee38e386bd62be9bedb990706951b65fe053bd9d8a521af753d139e2da;
-        hashes[5] = 0xdefff6d330bb5403f63b14f33b578274160de3a50df4efecf0e0db73bcdd3da5;
-        hashes[6] = 0x617bdd11f7c0a11f49db22f629387a12da7596f9d1704d7465177c63d88ec7d7;
-        hashes[7] = 0x292c23a9aa1d8bea7e2435e555a4a60e379a5a35f3f452bae60121073fb6eead;
-        hashes[8] = 0xe1cea92ed99acdcb045a6726b2f87107e8a61620a232cf4d7d5b5766b3952e10;
-        hashes[9] = 0x7ad66c0a68c72cb89e4fb4303841966e4062a76ab97451e3b9fb526a5ceb7f82;
-        hashes[10] = 0xe026cc5a4aed3c22a58cbd3d2ac754c9352c5436f638042dca99034e83636516;
-        hashes[11] = 0x3d04cffd8b46a874edf5cfae63077de85f849a660426697b06a829c70dd1409c;
-        hashes[12] = 0xad676aa337a485e4728a0b240d92b3ef7b3c372d06d189322bfd5f61f1e7203e;
-        hashes[13] = 0xa2fca4a49658f9fab7aa63289c91b7c7b6c832a6d0e69334ff5b0a3483d09dab;
-        hashes[14] = 0x4ebfd9cd7bca2505f7bef59cc1c12ecc708fff26ae4af19abe852afe9e20c862;
-        hashes[15] = 0x2def10d13dd169f550f578bda343d9717a138562e0093b380a1120789d53cf10;
-        hashes[16] = 0x776a31db34a1a0a7caaf862cffdfff1789297ffadc380bd3d39281d340abd3ad;
-        hashes[17] = 0xe2e7610b87a5fdf3a72ebe271287d923ab990eefac64b6e59d79f8b7e08c46e3;
-        hashes[18] = 0x504364a5c6858bf98fff714ab5be9de19ed31a976860efbd0e772a2efe23e2e0;
-        hashes[19] = 0x4f05f4acb83f5b65168d9fef89d56d4d77b8944015e6b1eed81b0238e2d0dba3;
-        hashes[20] = 0x44a6d974c75b07423e1d6d33f481916fdd45830aea11b6347e700cd8b9f0767c;
-        hashes[21] = 0xedf260291f734ddac396a956127dde4c34c0cfb8d8052f88ac139658ccf2d507;
-        hashes[22] = 0x6075c657a105351e7f0fce53bc320113324a522e8fd52dc878c762551e01a46e;
-        hashes[23] = 0x6ca6a3f763a9395f7da16014725ca7ee17e4815c0ff8119bf33f273dee11833b;
-        hashes[24] = 0x1c25ef10ffeb3c7d08aa707d17286e0b0d3cbcb50f1bd3b6523b63ba3b52dd0f;
-        hashes[25] = 0xfffc43bd08273ccf135fd3cacbeef055418e09eb728d727c4d5d5c556cdea7e3;
-        hashes[26] = 0xc5ab8111456b1f28f3c7a0a604b4553ce905cb019c463ee159137af83c350b22;
-        hashes[27] = 0x0ff273fcbf4ae0f2bd88d6cf319ff4004f8d7dca70d4ced4e74d2c74139739e6;
-        hashes[28] = 0x7fa06ba11241ddd5efdc65d4e39c9f6991b74fd4b81b62230808216c876f827c;
-        hashes[29] = 0x7e275adf313a996c7e2950cac67caba02a5ff925ebf9906b58949f3e77aec5b9;
-        hashes[30] = 0x8f6162fa308d2b3a15dc33cffac85f13ab349173121645aedf00f471663108be;
-        hashes[31] = 0x78ccaaab73373552f207a63599de54d7d8d0c1805f86ce7da15818d09f4cff62;
+        hashes[
+            0
+        ] = 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563;
+        hashes[
+            1
+        ] = 0x633dc4d7da7256660a892f8f1604a44b5432649cc8ec5cb3ced4c4e6ac94dd1d;
+        hashes[
+            2
+        ] = 0x890740a8eb06ce9be422cb8da5cdafc2b58c0a5e24036c578de2a433c828ff7d;
+        hashes[
+            3
+        ] = 0x3b8ec09e026fdc305365dfc94e189a81b38c7597b3d941c279f042e8206e0bd8;
+        hashes[
+            4
+        ] = 0xecd50eee38e386bd62be9bedb990706951b65fe053bd9d8a521af753d139e2da;
+        hashes[
+            5
+        ] = 0xdefff6d330bb5403f63b14f33b578274160de3a50df4efecf0e0db73bcdd3da5;
+        hashes[
+            6
+        ] = 0x617bdd11f7c0a11f49db22f629387a12da7596f9d1704d7465177c63d88ec7d7;
+        hashes[
+            7
+        ] = 0x292c23a9aa1d8bea7e2435e555a4a60e379a5a35f3f452bae60121073fb6eead;
+        hashes[
+            8
+        ] = 0xe1cea92ed99acdcb045a6726b2f87107e8a61620a232cf4d7d5b5766b3952e10;
+        hashes[
+            9
+        ] = 0x7ad66c0a68c72cb89e4fb4303841966e4062a76ab97451e3b9fb526a5ceb7f82;
+        hashes[
+            10
+        ] = 0xe026cc5a4aed3c22a58cbd3d2ac754c9352c5436f638042dca99034e83636516;
+        hashes[
+            11
+        ] = 0x3d04cffd8b46a874edf5cfae63077de85f849a660426697b06a829c70dd1409c;
+        hashes[
+            12
+        ] = 0xad676aa337a485e4728a0b240d92b3ef7b3c372d06d189322bfd5f61f1e7203e;
+        hashes[
+            13
+        ] = 0xa2fca4a49658f9fab7aa63289c91b7c7b6c832a6d0e69334ff5b0a3483d09dab;
+        hashes[
+            14
+        ] = 0x4ebfd9cd7bca2505f7bef59cc1c12ecc708fff26ae4af19abe852afe9e20c862;
+        hashes[
+            15
+        ] = 0x2def10d13dd169f550f578bda343d9717a138562e0093b380a1120789d53cf10;
+        hashes[
+            16
+        ] = 0x776a31db34a1a0a7caaf862cffdfff1789297ffadc380bd3d39281d340abd3ad;
+        hashes[
+            17
+        ] = 0xe2e7610b87a5fdf3a72ebe271287d923ab990eefac64b6e59d79f8b7e08c46e3;
+        hashes[
+            18
+        ] = 0x504364a5c6858bf98fff714ab5be9de19ed31a976860efbd0e772a2efe23e2e0;
+        hashes[
+            19
+        ] = 0x4f05f4acb83f5b65168d9fef89d56d4d77b8944015e6b1eed81b0238e2d0dba3;
+        hashes[
+            20
+        ] = 0x44a6d974c75b07423e1d6d33f481916fdd45830aea11b6347e700cd8b9f0767c;
+        hashes[
+            21
+        ] = 0xedf260291f734ddac396a956127dde4c34c0cfb8d8052f88ac139658ccf2d507;
+        hashes[
+            22
+        ] = 0x6075c657a105351e7f0fce53bc320113324a522e8fd52dc878c762551e01a46e;
+        hashes[
+            23
+        ] = 0x6ca6a3f763a9395f7da16014725ca7ee17e4815c0ff8119bf33f273dee11833b;
+        hashes[
+            24
+        ] = 0x1c25ef10ffeb3c7d08aa707d17286e0b0d3cbcb50f1bd3b6523b63ba3b52dd0f;
+        hashes[
+            25
+        ] = 0xfffc43bd08273ccf135fd3cacbeef055418e09eb728d727c4d5d5c556cdea7e3;
+        hashes[
+            26
+        ] = 0xc5ab8111456b1f28f3c7a0a604b4553ce905cb019c463ee159137af83c350b22;
+        hashes[
+            27
+        ] = 0x0ff273fcbf4ae0f2bd88d6cf319ff4004f8d7dca70d4ced4e74d2c74139739e6;
+        hashes[
+            28
+        ] = 0x7fa06ba11241ddd5efdc65d4e39c9f6991b74fd4b81b62230808216c876f827c;
+        hashes[
+            29
+        ] = 0x7e275adf313a996c7e2950cac67caba02a5ff925ebf9906b58949f3e77aec5b9;
+        hashes[
+            30
+        ] = 0x8f6162fa308d2b3a15dc33cffac85f13ab349173121645aedf00f471663108be;
+        hashes[
+            31
+        ] = 0x78ccaaab73373552f207a63599de54d7d8d0c1805f86ce7da15818d09f4cff62;
         return hashes[level];
     }
 
     function merklize(bytes32[] memory leaves) internal pure returns (bytes32) {
         require(leaves.length <= 32, "MerkleTree: Too many leaves");
         bytes32[6] memory hashes;
-        hashes[0] = 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563;
-        hashes[1] = 0x633dc4d7da7256660a892f8f1604a44b5432649cc8ec5cb3ced4c4e6ac94dd1d;
-        hashes[2] = 0x890740a8eb06ce9be422cb8da5cdafc2b58c0a5e24036c578de2a433c828ff7d;
-        hashes[3] = 0x3b8ec09e026fdc305365dfc94e189a81b38c7597b3d941c279f042e8206e0bd8;
-        hashes[4] = 0xecd50eee38e386bd62be9bedb990706951b65fe053bd9d8a521af753d139e2da;
-        hashes[5] = 0xdefff6d330bb5403f63b14f33b578274160de3a50df4efecf0e0db73bcdd3da5;
+        hashes[
+            0
+        ] = 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563;
+        hashes[
+            1
+        ] = 0x633dc4d7da7256660a892f8f1604a44b5432649cc8ec5cb3ced4c4e6ac94dd1d;
+        hashes[
+            2
+        ] = 0x890740a8eb06ce9be422cb8da5cdafc2b58c0a5e24036c578de2a433c828ff7d;
+        hashes[
+            3
+        ] = 0x3b8ec09e026fdc305365dfc94e189a81b38c7597b3d941c279f042e8206e0bd8;
+        hashes[
+            4
+        ] = 0xecd50eee38e386bd62be9bedb990706951b65fe053bd9d8a521af753d139e2da;
+        hashes[
+            5
+        ] = 0xdefff6d330bb5403f63b14f33b578274160de3a50df4efecf0e0db73bcdd3da5;
         uint256 odd = leaves.length & 1;
         uint256 n = (leaves.length + 1) >> 1;
         bytes32[] memory nodes = new bytes32[](n);

--- a/contracts/libs/Transition.sol
+++ b/contracts/libs/Transition.sol
@@ -105,11 +105,8 @@ library Transition {
             ),
             "Create2Transfer: receiver proof invalid"
         );
-        bytes memory encodedState = createState(
-            _tx.toPubkeyID,
-            tokenID,
-            _tx.amount
-        );
+        bytes memory encodedState =
+            createState(_tx.toPubkeyID, tokenID, _tx.amount);
 
         newRoot = MerkleTree.computeRoot(
             keccak256(encodedState),
@@ -136,10 +133,8 @@ library Transition {
             ),
             "Transition: Sender does not exist"
         );
-        (
-            Types.UserState memory newSender,
-            Types.Result result
-        ) = validateAndApplySender(tokenID, amount, fee, proof.state);
+        (Types.UserState memory newSender, Types.Result result) =
+            validateAndApplySender(tokenID, amount, fee, proof.state);
         if (result != Types.Result.Ok) return (bytes32(0), result);
         newRoot = MerkleTree.computeRoot(
             keccak256(newSender.encode()),
@@ -165,10 +160,8 @@ library Transition {
             ),
             "Transition: receiver does not exist"
         );
-        (
-            Types.UserState memory newReceiver,
-            Types.Result result
-        ) = validateAndApplyReceiver(tokenID, amount, proof.state);
+        (Types.UserState memory newReceiver, Types.Result result) =
+            validateAndApplyReceiver(tokenID, amount, proof.state);
         if (result != Types.Result.Ok) return (bytes32(0), result);
         newRoot = MerkleTree.computeRoot(
             keccak256(newReceiver.encode()),
@@ -190,12 +183,13 @@ library Transition {
             return (sender, Types.Result.NotEnoughTokenBalance);
         if (sender.tokenID != tokenID)
             return (sender, Types.Result.BadFromTokenID);
-        Types.UserState memory newSender = Types.UserState({
-            pubkeyID: sender.pubkeyID,
-            tokenID: sender.tokenID,
-            balance: sender.balance.sub(decrement),
-            nonce: sender.nonce.add(1)
-        });
+        Types.UserState memory newSender =
+            Types.UserState({
+                pubkeyID: sender.pubkeyID,
+                tokenID: sender.tokenID,
+                balance: sender.balance.sub(decrement),
+                nonce: sender.nonce.add(1)
+            });
         return (newSender, Types.Result.Ok);
     }
 
@@ -220,12 +214,13 @@ library Transition {
         uint256 tokenID,
         uint256 amount
     ) internal pure returns (bytes memory stateEncoded) {
-        Types.UserState memory state = Types.UserState({
-            pubkeyID: pubkeyID,
-            tokenID: tokenID,
-            balance: amount,
-            nonce: 0
-        });
+        Types.UserState memory state =
+            Types.UserState({
+                pubkeyID: pubkeyID,
+                tokenID: tokenID,
+                balance: amount,
+                nonce: 0
+            });
         return state.encode();
     }
 }

--- a/contracts/libs/Tx.sol
+++ b/contracts/libs/Tx.sol
@@ -103,12 +103,13 @@ library Tx {
             uint256 toIndex = txs[i].toIndex;
             uint256 amount = encodeDecimal(txs[i].amount);
             uint256 fee = encodeDecimal(txs[i].fee);
-            bytes memory _tx = abi.encodePacked(
-                uint32(fromIndex),
-                uint32(toIndex),
-                uint16(amount),
-                uint16(fee)
-            );
+            bytes memory _tx =
+                abi.encodePacked(
+                    uint32(fromIndex),
+                    uint32(toIndex),
+                    uint16(amount),
+                    uint16(fee)
+                );
             uint256 off = i * TX_LEN_0;
             for (uint256 j = 0; j < TX_LEN_0; j++) {
                 serialized[j + off] = _tx[j];
@@ -128,11 +129,12 @@ library Tx {
             uint256 fromIndex = txs[i].fromIndex;
             uint256 amount = encodeDecimal(txs[i].amount);
             uint256 fee = encodeDecimal(txs[i].fee);
-            bytes memory _tx = abi.encodePacked(
-                uint32(fromIndex),
-                uint16(amount),
-                uint16(fee)
-            );
+            bytes memory _tx =
+                abi.encodePacked(
+                    uint32(fromIndex),
+                    uint16(amount),
+                    uint16(fee)
+                );
             uint256 off = i * TX_LEN_5;
             for (uint256 j = 0; j < TX_LEN_5; j++) {
                 serialized[j + off] = _tx[j];
@@ -154,13 +156,14 @@ library Tx {
             uint256 toPubkeyID = txs[i].toPubkeyID;
             uint256 amount = txs[i].amount;
             uint256 fee = txs[i].fee;
-            bytes memory _tx = abi.encodePacked(
-                uint32(fromIndex),
-                uint32(toIndex),
-                uint32(toPubkeyID),
-                uint16(encodeDecimal(amount)),
-                uint16(encodeDecimal(fee))
-            );
+            bytes memory _tx =
+                abi.encodePacked(
+                    uint32(fromIndex),
+                    uint32(toIndex),
+                    uint32(toPubkeyID),
+                    uint16(encodeDecimal(amount)),
+                    uint16(encodeDecimal(fee))
+                );
             uint256 off = i * TX_LEN_1;
             for (uint256 j = 0; j < TX_LEN_1; j++) {
                 serialized[j + off] = _tx[j];

--- a/contracts/rollup/Rollup.sol
+++ b/contracts/rollup/Rollup.sol
@@ -25,8 +25,8 @@ contract Rollup is BatchManager {
     MassMigration public immutable massMigration;
     Create2Transfer public immutable create2Transfer;
 
-    bytes32
-        public constant ZERO_BYTES32 = 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563;
+    bytes32 public constant ZERO_BYTES32 =
+        0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563;
 
     uint256 public immutable paramMaxTxsPerCommit;
     bytes32 public immutable zeroHashAtSubtreeDepth;
@@ -70,14 +70,12 @@ contract Rollup is BatchManager {
             _depositManager.paramMaxSubtreeDepth()
         );
 
-        bytes32 genesisCommitment = keccak256(
-            abi.encode(genesisStateRoot, ZERO_BYTES32)
-        );
+        bytes32 genesisCommitment =
+            keccak256(abi.encode(genesisStateRoot, ZERO_BYTES32));
 
         // Same effect as `MerkleTree.merklize`
-        bytes32 commitmentRoot = keccak256(
-            abi.encode(genesisCommitment, ZERO_BYTES32)
-        );
+        bytes32 commitmentRoot =
+            keccak256(abi.encode(genesisCommitment, ZERO_BYTES32));
         batches[nextBatchID] = Types.Batch({
             commitmentRoot: commitmentRoot,
             meta: Types.encodeMeta(
@@ -245,16 +243,17 @@ contract Rollup is BatchManager {
         bytes32[] memory leaves = new bytes32[](stateRoots.length);
         bytes32 accountRoot = accountRegistry.root();
         for (uint256 i = 0; i < stateRoots.length; i++) {
-            Types.MassMigrationBody memory body = Types.MassMigrationBody(
-                accountRoot,
-                signatures[i],
-                meta[i][0],
-                withdrawRoots[i],
-                meta[i][1],
-                meta[i][2],
-                meta[i][3],
-                txss[i]
-            );
+            Types.MassMigrationBody memory body =
+                Types.MassMigrationBody(
+                    accountRoot,
+                    signatures[i],
+                    meta[i][0],
+                    withdrawRoots[i],
+                    meta[i][1],
+                    meta[i][2],
+                    meta[i][3],
+                    txss[i]
+                );
             leaves[i] = keccak256(
                 abi.encodePacked(stateRoots[i], Types.toHash(body))
             );
@@ -289,8 +288,8 @@ contract Rollup is BatchManager {
             ),
             "Rollup: State subtree is not vacant"
         );
-        (uint256 subtreeID, bytes32 depositSubTreeRoot) = depositManager
-            .dequeueToSubmit();
+        (uint256 subtreeID, bytes32 depositSubTreeRoot) =
+            depositManager.dequeueToSubmit();
         uint256 postBatchID = preBatchID + 1;
         // This deposit subtree is included in the batch whose ID is postBatchID
         deposits[postBatchID] = depositSubTreeRoot;
@@ -300,14 +299,14 @@ contract Rollup is BatchManager {
             vacant.pathAtDepth
         );
 
-        bytes32 newRoot = MerkleTree.computeRoot(
-            depositSubTreeRoot,
-            vacant.pathAtDepth,
-            vacant.witness
-        );
-        bytes32 depositCommitment = keccak256(
-            abi.encode(newRoot, ZERO_BYTES32)
-        );
+        bytes32 newRoot =
+            MerkleTree.computeRoot(
+                depositSubTreeRoot,
+                vacant.pathAtDepth,
+                vacant.witness
+            );
+        bytes32 depositCommitment =
+            keccak256(abi.encode(newRoot, ZERO_BYTES32));
         // Same effect as `MerkleTree.merklize`
         bytes32 root = keccak256(abi.encode(depositCommitment, ZERO_BYTES32));
         // AccountRoot doesn't matter for deposit, add dummy value
@@ -329,14 +328,14 @@ contract Rollup is BatchManager {
             "Target commitment is absent in the batch"
         );
 
-        (bytes32 processedStateRoot, Types.Result result) = transfer
-            .processTransferCommit(
-            previous.commitment.stateRoot,
-            paramMaxTxsPerCommit,
-            target.commitment.body.feeReceiver,
-            target.commitment.body.txs,
-            proofs
-        );
+        (bytes32 processedStateRoot, Types.Result result) =
+            transfer.processTransferCommit(
+                previous.commitment.stateRoot,
+                paramMaxTxsPerCommit,
+                target.commitment.body.feeReceiver,
+                target.commitment.body.txs,
+                proofs
+            );
 
         if (
             result != Types.Result.Ok ||
@@ -359,13 +358,13 @@ contract Rollup is BatchManager {
             "Target commitment is absent in the batch"
         );
 
-        (bytes32 processedStateRoot, Types.Result result) = massMigration
-            .processMassMigrationCommit(
-            previous.commitment.stateRoot,
-            paramMaxTxsPerCommit,
-            target.commitment.body,
-            proofs
-        );
+        (bytes32 processedStateRoot, Types.Result result) =
+            massMigration.processMassMigrationCommit(
+                previous.commitment.stateRoot,
+                paramMaxTxsPerCommit,
+                target.commitment.body,
+                proofs
+            );
 
         if (
             result != Types.Result.Ok ||
@@ -388,14 +387,14 @@ contract Rollup is BatchManager {
             "Target commitment is absent in the batch"
         );
 
-        (bytes32 processedStateRoot, Types.Result result) = create2Transfer
-            .processCreate2TransferCommit(
-            previous.commitment.stateRoot,
-            paramMaxTxsPerCommit,
-            target.commitment.body.feeReceiver,
-            target.commitment.body.txs,
-            proofs
-        );
+        (bytes32 processedStateRoot, Types.Result result) =
+            create2Transfer.processCreate2TransferCommit(
+                previous.commitment.stateRoot,
+                paramMaxTxsPerCommit,
+                target.commitment.body.feeReceiver,
+                target.commitment.body.txs,
+                proofs
+            );
 
         if (
             result != Types.Result.Ok ||
@@ -412,13 +411,14 @@ contract Rollup is BatchManager {
             checkInclusion(batches[batchID].commitmentRoot, target),
             "Rollup: Commitment not present in batch"
         );
-        Types.AuthCommon memory common = Types.AuthCommon({
-            signature: target.commitment.body.signature,
-            stateRoot: target.commitment.stateRoot,
-            accountRoot: target.commitment.body.accountRoot,
-            domain: appID,
-            txs: target.commitment.body.txs
-        });
+        Types.AuthCommon memory common =
+            Types.AuthCommon({
+                signature: target.commitment.body.signature,
+                stateRoot: target.commitment.stateRoot,
+                accountRoot: target.commitment.body.accountRoot,
+                domain: appID,
+                txs: target.commitment.body.txs
+            });
         Types.Result result = transfer.checkSignature(common, signatureProof);
 
         if (result != Types.Result.Ok) startRollingBack(batchID);
@@ -433,19 +433,21 @@ contract Rollup is BatchManager {
             checkInclusion(batches[batchID].commitmentRoot, target),
             "Commitment not present in batch"
         );
-        Types.AuthCommon memory common = Types.AuthCommon({
-            signature: target.commitment.body.signature,
-            stateRoot: target.commitment.stateRoot,
-            accountRoot: target.commitment.body.accountRoot,
-            domain: appID,
-            txs: target.commitment.body.txs
-        });
+        Types.AuthCommon memory common =
+            Types.AuthCommon({
+                signature: target.commitment.body.signature,
+                stateRoot: target.commitment.stateRoot,
+                accountRoot: target.commitment.body.accountRoot,
+                domain: appID,
+                txs: target.commitment.body.txs
+            });
 
-        Types.Result result = massMigration.checkSignature(
-            common,
-            signatureProof,
-            target.commitment.body.spokeID
-        );
+        Types.Result result =
+            massMigration.checkSignature(
+                common,
+                signatureProof,
+                target.commitment.body.spokeID
+            );
 
         if (result != Types.Result.Ok) startRollingBack(batchID);
     }
@@ -459,18 +461,17 @@ contract Rollup is BatchManager {
             checkInclusion(batches[batchID].commitmentRoot, target),
             "Rollup: Commitment not present in batch"
         );
-        Types.AuthCommon memory common = Types.AuthCommon({
-            signature: target.commitment.body.signature,
-            stateRoot: target.commitment.stateRoot,
-            accountRoot: target.commitment.body.accountRoot,
-            domain: appID,
-            txs: target.commitment.body.txs
-        });
+        Types.AuthCommon memory common =
+            Types.AuthCommon({
+                signature: target.commitment.body.signature,
+                stateRoot: target.commitment.stateRoot,
+                accountRoot: target.commitment.body.accountRoot,
+                domain: appID,
+                txs: target.commitment.body.txs
+            });
 
-        Types.Result result = create2Transfer.checkSignature(
-            common,
-            signatureProof
-        );
+        Types.Result result =
+            create2Transfer.checkSignature(common, signatureProof);
 
         if (result != Types.Result.Ok) startRollingBack(batchID);
     }

--- a/contracts/test/TestCreate2Transfer.sol
+++ b/contracts/test/TestCreate2Transfer.sol
@@ -17,13 +17,14 @@ contract TestCreate2Transfer is Create2Transfer {
         bytes memory txs
     ) public returns (uint256, Types.Result) {
         uint256 operationCost = gasleft();
-        Types.AuthCommon memory common = Types.AuthCommon({
-            signature: signature,
-            stateRoot: stateRoot,
-            accountRoot: accountRoot,
-            domain: domain,
-            txs: txs
-        });
+        Types.AuthCommon memory common =
+            Types.AuthCommon({
+                signature: signature,
+                stateRoot: stateRoot,
+                accountRoot: accountRoot,
+                domain: domain,
+                txs: txs
+            });
         Types.Result err = checkSignature(common, proof);
         return (operationCost - gasleft(), err);
     }

--- a/contracts/test/TestMassMigration.sol
+++ b/contracts/test/TestMassMigration.sol
@@ -16,13 +16,14 @@ contract TestMassMigration is MassMigration {
         bytes memory txs
     ) public view returns (uint256 gasCost, Types.Result result) {
         gasCost = gasleft();
-        Types.AuthCommon memory common = Types.AuthCommon({
-            signature: signature,
-            stateRoot: stateRoot,
-            accountRoot: accountRoot,
-            domain: domain,
-            txs: txs
-        });
+        Types.AuthCommon memory common =
+            Types.AuthCommon({
+                signature: signature,
+                stateRoot: stateRoot,
+                accountRoot: accountRoot,
+                domain: domain,
+                txs: txs
+            });
         result = checkSignature(common, proof, spokeID);
         gasCost = gasCost - gasleft();
     }
@@ -42,12 +43,13 @@ contract TestMassMigration is MassMigration {
         )
     {
         gasCost = gasleft();
-        (bytes32 postRoot, Types.Result result) = processMassMigrationCommit(
-            stateRoot,
-            maxTxSize,
-            commitmentBody,
-            proofs
-        );
+        (bytes32 postRoot, Types.Result result) =
+            processMassMigrationCommit(
+                stateRoot,
+                maxTxSize,
+                commitmentBody,
+                proofs
+            );
         return (gasCost - gasleft(), postRoot, result);
     }
 }

--- a/contracts/test/TestTransfer.sol
+++ b/contracts/test/TestTransfer.sol
@@ -17,13 +17,14 @@ contract TestTransfer is Transfer {
         bytes memory txs
     ) public returns (uint256, Types.Result) {
         uint256 operationCost = gasleft();
-        Types.AuthCommon memory common = Types.AuthCommon({
-            signature: signature,
-            stateRoot: stateRoot,
-            accountRoot: accountRoot,
-            domain: domain,
-            txs: txs
-        });
+        Types.AuthCommon memory common =
+            Types.AuthCommon({
+                signature: signature,
+                stateRoot: stateRoot,
+                accountRoot: accountRoot,
+                domain: domain,
+                txs: txs
+            });
         Types.Result result = checkSignature(common, proof);
         return (operationCost - gasleft(), result);
     }

--- a/contracts/test/TestTypes.sol
+++ b/contracts/test/TestTypes.sol
@@ -32,10 +32,8 @@ contract TestTypes {
             uint256 finaliseOn
         )
     {
-        Types.Batch memory batch = Types.Batch({
-            commitmentRoot: bytes32(0),
-            meta: meta
-        });
+        Types.Batch memory batch =
+            Types.Batch({ commitmentRoot: bytes32(0), meta: meta });
         batchType = batch.batchType();
         size = batch.size();
         committer = batch.committer();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1753,15 +1753,6 @@
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
-    "esprima-extract-comments": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/esprima-extract-comments/-/esprima-extract-comments-1.1.0.tgz",
-      "integrity": "sha512-sBQUnvJwpeE9QnPrxh7dpI/dp67erYG4WXEAreAMoelPRpMR7NWb4YtwRPn9b+H1uLQKl/qS8WYmyaljTpjIsw==",
-      "dev": true,
-      "requires": {
-        "esprima": "^4.0.0"
-      }
-    },
     "esquery": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
@@ -2000,16 +1991,6 @@
         "chardet": "^0.7.0",
         "iconv-lite": "^0.4.24",
         "tmp": "^0.0.33"
-      }
-    },
-    "extract-comments": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/extract-comments/-/extract-comments-1.1.0.tgz",
-      "integrity": "sha512-dzbZV2AdSSVW/4E7Ti5hZdHWbA+Z80RJsJhr5uiL10oyjl/gy7/o+HI1HwK4/WSZhlq4SNKU3oUzXlM13Qx02Q==",
-      "dev": true,
-      "requires": {
-        "esprima-extract-comments": "^1.1.0",
-        "parse-code-context": "^1.0.0"
       }
     },
     "fast-decode-uri-component": {
@@ -6427,12 +6408,6 @@
         }
       }
     },
-    "parse-code-context": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/parse-code-context/-/parse-code-context-1.0.0.tgz",
-      "integrity": "sha512-OZQaqKaQnR21iqhlnPfVisFjBWjhnMl5J9MgbP8xC+EwoVqbXrq78lp+9Zb3ahmLzrIX5Us/qbvBnaS3hkH6OA==",
-      "dev": true
-    },
     "parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -6529,25 +6504,25 @@
       "dev": true
     },
     "prettier-plugin-solidity": {
-      "version": "1.0.0-alpha.59",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0-alpha.59.tgz",
-      "integrity": "sha512-6cE0SWaiYCBoJY4clCfsbWlEEOU4K42Ny6Tg4Jwprgts/q+AVfYnPQ5coRs7zIjYzc4RVspifYPeh+oAg8RpLw==",
+      "version": "1.0.0-beta.10",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0-beta.10.tgz",
+      "integrity": "sha512-55UsEbeJfqYKB3RFR7Nvpi+ApEoUfgdKHVg2ZybrbOkRW4RTblyONLL3mEr8Vrxpo7wBbObVLbWodGg4YXIQ7g==",
       "dev": true,
       "requires": {
-        "@solidity-parser/parser": "^0.8.1",
+        "@solidity-parser/parser": "^0.12.1",
         "dir-to-object": "^2.0.0",
-        "emoji-regex": "^9.0.0",
+        "emoji-regex": "^9.2.2",
         "escape-string-regexp": "^4.0.0",
-        "extract-comments": "^1.1.0",
-        "prettier": "^2.0.5",
-        "semver": "^7.3.2",
-        "string-width": "^4.2.0"
+        "prettier": "^2.2.1",
+        "semver": "^7.3.5",
+        "solidity-comments-extractor": "^0.0.7",
+        "string-width": "^4.2.2"
       },
       "dependencies": {
         "@solidity-parser/parser": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.8.2.tgz",
-          "integrity": "sha512-8LySx3qrNXPgB5JiULfG10O3V7QTxI/TLzSw5hFQhXWSkVxZBAv4rZQ0sYgLEbc8g3L2lmnujj1hKul38Eu5NQ==",
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.12.1.tgz",
+          "integrity": "sha512-ikxVpwskNxEp2fvYS1BdRImnevHmM97zdPFBa1cVtjtNpoqCm/EmljATTZk0s9G/zsN5ZbPf9OAIAW4gbBJiRA==",
           "dev": true
         },
         "ansi-regex": {
@@ -6590,9 +6565,9 @@
           "dev": true
         },
         "semver": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -7061,6 +7036,12 @@
           "dev": true
         }
       }
+    },
+    "solidity-comments-extractor": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/solidity-comments-extractor/-/solidity-comments-extractor-0.0.7.tgz",
+      "integrity": "sha512-wciNMLg/Irp8OKGrh3S2tfvZiZ0NEyILfcRCXCD4mp7SgK/i9gzLfhY2hY7VMCQJ3kH9UB9BzNdibIVMchzyYw==",
+      "dev": true
     },
     "sonic-boom": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "mcl-wasm": "^0.4.5",
     "minimist": "^1.2.5",
     "prettier": "^1.19.1",
-    "prettier-plugin-solidity": "^1.0.0-alpha.59",
+    "prettier-plugin-solidity": "1.0.0-beta.10",
     "solhint": "^3.3.3",
     "ts-node": "^8.8.1",
     "typechain": "^2.0.1",


### PR DESCRIPTION
Resolves https://github.com/thehubbleproject/hubble-contracts/issues/555

This update changes the formatting on a number of contracts. Not sure if this is desired. May be able to configure prettier solidity rules to keep old formatting with new lib version.