### PR TITLE
Sync DepositQueued event

### DIFF
--- a/ts/client/features/base.ts
+++ b/ts/client/features/base.ts
@@ -46,22 +46,22 @@ export class ConcreteBatch<T extends Commitment> implements Batch {
         return this.tree.root;
     }
 
-    witness(leafInfex: number): string[] {
-        return this.tree.witness(leafInfex).nodes;
+    witness(leafIndex: number): string[] {
+        return this.tree.witness(leafIndex).nodes;
     }
 
-    proof(leafInfex: number): XCommitmentInclusionProof {
+    proof(leafIndex: number): XCommitmentInclusionProof {
         return {
-            commitment: this.commitments[leafInfex].toSolStruct(),
-            path: leafInfex,
-            witness: this.witness(leafInfex)
+            commitment: this.commitments[leafIndex].toSolStruct(),
+            path: leafIndex,
+            witness: this.witness(leafIndex)
         };
     }
-    proofCompressed(leafInfex: number): CommitmentInclusionProof {
+    proofCompressed(leafIndex: number): CommitmentInclusionProof {
         return {
-            commitment: this.commitments[leafInfex].toCompressedStruct(),
-            path: leafInfex,
-            witness: this.witness(leafInfex)
+            commitment: this.commitments[leafIndex].toCompressedStruct(),
+            path: leafIndex,
+            witness: this.witness(leafIndex)
         };
     }
 

--- a/ts/client/features/deposit.ts
+++ b/ts/client/features/deposit.ts
@@ -24,13 +24,14 @@ export class DepositPool {
         this.subtreeQueue = [];
     }
 
-    pushDeposit(encodedState: BytesLike) {
+    public pushDeposit(encodedState: BytesLike) {
         const state = State.fromEncoded(encodedState);
         this.depositLeaves.push(state);
         if (this.depositLeaves.length >= this.paramMaxSubtreeSize) {
             this.pushSubtree();
         }
     }
+
     private pushSubtree() {
         const states = this.depositLeaves.slice();
         const root = Tree.merklize(states.map(s => s.hash())).root;
@@ -38,9 +39,9 @@ export class DepositPool {
         this.subtreeQueue.push({ states, root });
     }
 
-    popDepositSubtree(): Subtree {
+    public popDepositSubtree(): Subtree {
         const subtree = this.subtreeQueue.shift();
-        if (!subtree) throw new Error("no subtre available");
+        if (!subtree) throw new Error("no subtree available");
         return subtree;
     }
 }

--- a/ts/client/services/events/batchPubkeyRegistered.ts
+++ b/ts/client/services/events/batchPubkeyRegistered.ts
@@ -1,0 +1,47 @@
+import { Event } from "ethers";
+import { CoreAPI } from "../../coreAPI";
+import { PubkeyStorageEngine } from "../../storageEngine";
+import { ContractEventSyncer } from "./contractEventSyncer";
+
+/**
+ * Syncs batchPubkeyRegistered events from the blsAccountRegistry contract
+ */
+export class BatchPubkeyRegisteredEventSyncer extends ContractEventSyncer {
+    private readonly pubkeyStorage: PubkeyStorageEngine;
+
+    constructor(api: CoreAPI) {
+        super(
+            api.contracts.blsAccountRegistry,
+            api.contracts.blsAccountRegistry.filters.BatchPubkeyRegistered(
+                null,
+                null
+            )
+        );
+        this.eventListener = this.batchPubkeyRegisteredListener;
+
+        this.pubkeyStorage = api.l2Storage.pubkey;
+    }
+
+    public async initialSync(
+        _startBlock: number,
+        _endBlock: number
+    ): Promise<void> {
+        console.error(
+            "BatchPubkeyRegisteredEventSyncer: initialSync not implemented."
+        );
+    }
+
+    private async handleBatchPubkeyRegistered(_event: Event) {
+        console.error(
+            "BatchPubkeyRegisteredEventSyncer: handleBatchPubkeyRegistered not implemented."
+        );
+    }
+
+    batchPubkeyRegisteredListener = async (
+        startID: null,
+        endID: null,
+        event: Event
+    ) => {
+        await this.handleBatchPubkeyRegistered(event);
+    };
+}

--- a/ts/client/services/events/contractEventSyncer.ts
+++ b/ts/client/services/events/contractEventSyncer.ts
@@ -1,0 +1,54 @@
+import { EventFilter } from "@ethersproject/contracts";
+import { Listener } from "@ethersproject/abstract-provider";
+import { Contract, Event } from "ethers";
+import { EventSyncer } from "./interfaces";
+
+/**
+ * Abstract class for common EventSyncers that watch a contract for events.
+ * Be sure to:
+ *  - Override initialSync. See getEvents for a convenient way to get events.
+ *  - Set an eventListener after construction. This is done
+ * to allow proper 'this' scope binding for callbacks.
+ */
+export abstract class ContractEventSyncer implements EventSyncer {
+    protected eventListener?: Listener;
+
+    /**
+     * @param contract The contract to listen to.
+     * @param filter The event filter.
+     */
+    constructor(
+        protected readonly contract: Contract,
+        protected readonly filter: EventFilter
+    ) {}
+
+    public async initialSync(
+        _startBlock: number,
+        _endBlock: number
+    ): Promise<void> {
+        throw new Error("EventSyncerBase: Method initialSync not implemented.");
+    }
+
+    public listen() {
+        if (!this.eventListener) {
+            throw new Error("EventSyncerBase: eventListener not set.");
+        }
+
+        this.contract.addListener(this.filter, this.eventListener);
+    }
+
+    public stopListening() {
+        if (!this.eventListener) {
+            throw new Error("EventSyncerBase: eventListener not set.");
+        }
+
+        this.contract.removeListener(this.filter, this.eventListener);
+    }
+
+    protected async getEvents(
+        startBlock: number,
+        endBlock: number
+    ): Promise<Event[]> {
+        return this.contract.queryFilter(this.filter, startBlock, endBlock);
+    }
+}

--- a/ts/client/services/events/depositQueued.ts
+++ b/ts/client/services/events/depositQueued.ts
@@ -1,0 +1,51 @@
+import { Event } from "ethers";
+import { State } from "../../../state";
+import { CoreAPI } from "../../coreAPI";
+import { DepositPool } from "../../features/deposit";
+import { ContractEventSyncer } from "./contractEventSyncer";
+
+/**
+ * Syncs DepositQueued events from the despositManager contract
+ */
+export class DepositQueuedEventSyncer extends ContractEventSyncer {
+    private readonly depositPool: DepositPool;
+
+    constructor(api: CoreAPI) {
+        super(
+            api.contracts.depositManager,
+            api.contracts.depositManager.filters.DepositQueued(null, null, null)
+        );
+        this.eventListener = this.depositQueuedListener;
+
+        this.depositPool = api.depositPool;
+    }
+
+    public async initialSync(
+        startBlock: number,
+        endBlock: number
+    ): Promise<void> {
+        const events = await this.getEvents(startBlock, endBlock);
+        console.info(
+            `Block ${startBlock} -- ${endBlock}\t${events.length} new deposits queued`
+        );
+        for (const event of events) {
+            this.handleDepositQueued(event);
+        }
+    }
+
+    private handleDepositQueued(event: Event) {
+        const depositState = State.fromDepositQueuedEvent(event);
+        this.depositPool.pushDeposit(depositState.encode());
+
+        console.info(`Deposit queued ${depositState.toString()}`);
+    }
+
+    depositQueuedListener = (
+        pubkeyID: null,
+        tokenID: null,
+        l2Amount: null,
+        event: Event
+    ) => {
+        this.handleDepositQueued(event);
+    };
+}

--- a/ts/client/services/events/interfaces.ts
+++ b/ts/client/services/events/interfaces.ts
@@ -1,0 +1,22 @@
+/**
+ * Represents an object that can sync L1 events
+ * to local state (L2).
+ */
+export interface EventSyncer {
+    /**
+     * Syncs events from L1 to local state (L2)
+     * for a given range of blocks.
+     *
+     * @param startBlock The block number to start searching from.
+     * @param endBlock  The block number to search to.
+     */
+    initialSync(startBlock: number, endBlock: number): Promise<void>;
+    /**
+     * Starts listening for new events to sync.
+     */
+    listen(): void;
+    /**
+     * Stops listening for new events to sync.
+     */
+    stopListening(): void;
+}

--- a/ts/client/services/events/newBatch.ts
+++ b/ts/client/services/events/newBatch.ts
@@ -1,0 +1,63 @@
+import { Event } from "ethers";
+import { Usage } from "../../../interfaces";
+import { BatchHandlingContext } from "../../contexts";
+import { CoreAPI, SyncedPoint } from "../../coreAPI";
+import { ContractEventSyncer } from "./contractEventSyncer";
+
+/**
+ * Syncs newBatch events from the rollup contract
+ */
+export class NewBatchEventSyncer extends ContractEventSyncer {
+    private readonly batchHandlingContext: BatchHandlingContext;
+    private readonly syncpoint: SyncedPoint;
+
+    constructor(api: CoreAPI) {
+        super(api.rollup, api.rollup.filters.NewBatch(null, null, null));
+        this.eventListener = this.newBatchListener;
+
+        this.syncpoint = api.syncpoint;
+        this.batchHandlingContext = new BatchHandlingContext(api);
+    }
+
+    public async initialSync(
+        startBlock: number,
+        endBlock: number
+    ): Promise<void> {
+        const events = await this.getEvents(startBlock, endBlock);
+        console.info(
+            `Block ${startBlock} -- ${endBlock}\t${events.length} new batches`
+        );
+        for (const event of events) {
+            await this.handleNewBatch(event);
+        }
+    }
+
+    private async handleNewBatch(event: Event) {
+        const usage = event.args?.batchType as Usage;
+        const batchID = Number(event.args?.batchID);
+        if (this.syncpoint.batchID >= batchID) {
+            console.info(
+                "synced before",
+                "synced batchID",
+                this.syncpoint.batchID,
+                "this batchID",
+                batchID
+            );
+            return;
+        }
+        this.batchHandlingContext.setStrategy(usage);
+        const batch = await this.batchHandlingContext.parseBatch(event);
+        await this.batchHandlingContext.processBatch(batch);
+        this.syncpoint.update(event.blockNumber, batchID);
+        console.info(`#${batchID}  [${Usage[usage]}]`, batch.toString());
+    }
+
+    newBatchListener = async (
+        batchID: null,
+        accountRoot: null,
+        batchType: null,
+        event: Event
+    ) => {
+        await this.handleNewBatch(event);
+    };
+}

--- a/ts/client/services/events/sequentialCompositeEventSyncer.ts
+++ b/ts/client/services/events/sequentialCompositeEventSyncer.ts
@@ -1,0 +1,32 @@
+import { EventSyncer } from "./interfaces";
+
+/**
+ * Group of EventSyncers which behave like one EventSyncer.
+ * initialSync will process the syncers in sequential order.
+ * https://en.wikipedia.org/wiki/Composite_pattern
+ */
+export default class SequentialCompositeEventSyncer implements EventSyncer {
+    constructor(private readonly syncers: EventSyncer[]) {}
+
+    public async initialSync(
+        startBlock: number,
+        endBlock: number
+    ): Promise<void> {
+        await this.syncers.reduce(async (prev, cur) => {
+            await prev;
+            await cur.initialSync(startBlock, endBlock);
+        }, Promise.resolve());
+    }
+
+    listen(): void {
+        for (let es of this.syncers) {
+            es.listen();
+        }
+    }
+
+    stopListening(): void {
+        for (let es of this.syncers) {
+            es.stopListening();
+        }
+    }
+}

--- a/ts/client/services/events/sequentialCompositeEventSyncer.ts
+++ b/ts/client/services/events/sequentialCompositeEventSyncer.ts
@@ -5,7 +5,7 @@ import { EventSyncer } from "./interfaces";
  * initialSync will process the syncers in sequential order.
  * https://en.wikipedia.org/wiki/Composite_pattern
  */
-export default class SequentialCompositeEventSyncer implements EventSyncer {
+export class SequentialCompositeEventSyncer implements EventSyncer {
     constructor(private readonly syncers: EventSyncer[]) {}
 
     public async initialSync(

--- a/ts/client/services/events/sequentialCompositeEventSyncer.ts
+++ b/ts/client/services/events/sequentialCompositeEventSyncer.ts
@@ -18,13 +18,13 @@ export class SequentialCompositeEventSyncer implements EventSyncer {
         }, Promise.resolve());
     }
 
-    listen(): void {
+    public listen(): void {
         for (let es of this.syncers) {
             es.listen();
         }
     }
 
-    stopListening(): void {
+    public stopListening(): void {
         for (let es of this.syncers) {
             es.stopListening();
         }

--- a/ts/client/services/events/singlePubkeyRegistered.ts
+++ b/ts/client/services/events/singlePubkeyRegistered.ts
@@ -1,0 +1,68 @@
+import { Event } from "ethers";
+import { chunk } from "lodash";
+import { Pubkey } from "../../../pubkey";
+import { CoreAPI } from "../../coreAPI";
+import { PubkeyStorageEngine } from "../../storageEngine";
+import { ContractEventSyncer } from "./contractEventSyncer";
+
+/**
+ * Syncs singlePubkeyRegistered events from the blsAccountRegistry contract
+ */
+export class SinglePubkeyRegisteredEventSyncer extends ContractEventSyncer {
+    private readonly pubkeyStorage: PubkeyStorageEngine;
+
+    constructor(api: CoreAPI) {
+        super(
+            api.contracts.blsAccountRegistry,
+            api.contracts.blsAccountRegistry.filters.SinglePubkeyRegistered(
+                null
+            )
+        );
+        this.eventListener = this.singlePubkeyRegisteredListener;
+
+        this.pubkeyStorage = api.l2Storage.pubkey;
+    }
+
+    public async initialSync(
+        startBlock: number,
+        endBlock: number
+    ): Promise<void> {
+        const events = await this.getEvents(startBlock, endBlock);
+        console.info(
+            `Block ${startBlock} -- ${endBlock}\t${events.length} new single public key registrations`
+        );
+        await chunk(events, 10).reduce(async (prev, eventsChunk) => {
+            await prev;
+            await Promise.all(
+                eventsChunk.map(e => this.handleSinglePubkeyRegistered(e))
+            );
+            await this.commitUpdate();
+        }, Promise.resolve());
+    }
+
+    private async commitUpdate() {
+        await this.pubkeyStorage.commit();
+    }
+
+    private getPubkeyFromTxn(txn: { data: string }): Pubkey {
+        // Get public key from registration call data
+        const { args } = this.contract.interface.parseTransaction(txn);
+        return new Pubkey(args.pubkey);
+    }
+
+    private async handleSinglePubkeyRegistered(event: Event) {
+        const pubkeyID = event.args?.pubkeyID;
+
+        const txn = await event.getTransaction();
+        const pubkey = this.getPubkeyFromTxn(txn);
+
+        await this.pubkeyStorage.update(pubkeyID, pubkey);
+
+        console.info(`Pubkey added ID ${pubkeyID} ${pubkey.toString()}`);
+    }
+
+    singlePubkeyRegisteredListener = async (pubkeyID: null, event: Event) => {
+        await this.handleSinglePubkeyRegistered(event);
+        await this.commitUpdate();
+    };
+}

--- a/ts/client/services/syncer.ts
+++ b/ts/client/services/syncer.ts
@@ -1,13 +1,10 @@
-import { Event, EventFilter } from "@ethersproject/contracts";
-import { chunk } from "lodash";
-import { BlsAccountRegistry } from "../../../types/ethers-contracts/BlsAccountRegistry";
 import { CoreAPI } from "../coreAPI";
 import { nodeEmitter, SyncCompleteEvent } from "../node";
-import { PubkeyStorageEngine } from "../storageEngine";
-import { Pubkey } from "../../pubkey";
 import { EventSyncer } from "./events/interfaces";
 import { NewBatchEventSyncer } from "./events/newBatch";
-import SequentialCompositeEventSyncer from "./events/sequentialCompositeEventSyncer";
+import { SequentialCompositeEventSyncer } from "./events/sequentialCompositeEventSyncer";
+import { BatchPubkeyRegisteredEventSyncer } from "./events/batchPubkeyRegistered";
+import { SinglePubkeyRegisteredEventSyncer } from "./events/singlePubkeyRegistered";
 
 export enum SyncMode {
     INITIAL_SYNCING,
@@ -16,27 +13,16 @@ export enum SyncMode {
 
 export class SyncerService {
     private mode: SyncMode;
-    private singlePubkeyRegisteredFilter: EventFilter;
-    private batchPubkeyRegisteredFilter: EventFilter;
-    private accountRegistry: BlsAccountRegistry;
-    private pubkeyStorage: PubkeyStorageEngine;
     private readonly events: EventSyncer;
 
     constructor(private readonly api: CoreAPI) {
         this.mode = SyncMode.INITIAL_SYNCING;
-        this.accountRegistry = this.api.contracts.blsAccountRegistry;
-        this.singlePubkeyRegisteredFilter = this.accountRegistry.filters.SinglePubkeyRegistered(
-            null
-        );
-        this.batchPubkeyRegisteredFilter = this.accountRegistry.filters.BatchPubkeyRegistered(
-            null,
-            null
-        );
-        this.pubkeyStorage = this.api.l2Storage.pubkey;
 
         this.events = new SequentialCompositeEventSyncer([
             // Note: Ordering here is important for initial syncs.
             // Pubkey syncs need to happen before batch syncs, etc.
+            new SinglePubkeyRegisteredEventSyncer(api),
+            new BatchPubkeyRegisteredEventSyncer(api),
             new NewBatchEventSyncer(api)
         ]);
     }
@@ -51,43 +37,6 @@ export class SyncerService {
         this.mode = SyncMode.REGULAR_SYNCING;
 
         this.events.listen();
-
-        this.accountRegistry.on(
-            this.singlePubkeyRegisteredFilter,
-            this.singlePubkeyRegisteredListener
-        );
-        this.accountRegistry.on(
-            this.batchPubkeyRegisteredFilter,
-            this.batchPubkeyRegisteredListener
-        );
-    }
-
-    async initialPubkeyRegisteredSync(start: number, end: number) {
-        await Promise.all([
-            this.initialSinglePubkeyRegisteredSync(start, end),
-            this.initialBatchPubkeyRegisteredSync(start, end)
-        ]);
-    }
-
-    async initialSinglePubkeyRegisteredSync(start: number, end: number) {
-        const events = await this.accountRegistry.queryFilter(
-            this.singlePubkeyRegisteredFilter,
-            start,
-            end
-        );
-        console.info(
-            `Block ${start} -- ${end}\t${events.length} new single public key registrations`
-        );
-        await chunk(events, 10).reduce(async (prev, eventsChunk) => {
-            await prev;
-            await Promise.all(
-                eventsChunk.map(e => this.handleSinglePubkeyRegistered(e))
-            );
-        }, Promise.resolve());
-    }
-
-    async initialBatchPubkeyRegisteredSync(_start: number, _end: number) {
-        console.error("initialBatchPubkeyRegisteredSync not implemented");
     }
 
     async initialSync() {
@@ -98,7 +47,6 @@ export class SyncerService {
         while (start <= latestBlock) {
             const end = start + chunksize - 1;
 
-            await this.initialPubkeyRegisteredSync(start, end);
             await this.events.initialSync(start, end);
 
             start = end + 1;
@@ -110,51 +58,9 @@ export class SyncerService {
         }
     }
 
-    getPubkeyFromTxn(txn: { data: string }): Pubkey {
-        // Get public key from registration call data
-        const { args } = this.accountRegistry.interface.parseTransaction(txn);
-        return new Pubkey(args.pubkey);
-    }
-
-    async handleSinglePubkeyRegistered(event: Event) {
-        const pubkeyID = event.args?.pubkeyID;
-
-        const txn = await event.getTransaction();
-        const pubkey = this.getPubkeyFromTxn(txn);
-
-        await this.pubkeyStorage.update(pubkeyID, pubkey);
-        await this.pubkeyStorage.commit();
-
-        console.info(`Pubkey added ID ${pubkeyID} ${pubkey.toString()}`);
-    }
-
-    async handleBatchPubkeyRegistered(_event: Event) {
-        console.error("handleBatchPubkeyRegistered not implemented");
-    }
-
-    singlePubkeyRegisteredListener = async (pubkeyID: null, event: Event) => {
-        await this.handleSinglePubkeyRegistered(event);
-    };
-
-    batchPubkeyRegisteredListener = async (
-        startID: null,
-        endID: null,
-        event: Event
-    ) => {
-        await this.handleBatchPubkeyRegistered(event);
-    };
-
     stop() {
         if (this.mode == SyncMode.REGULAR_SYNCING) {
             this.events.stopListening();
-            this.accountRegistry.removeListener(
-                this.singlePubkeyRegisteredFilter,
-                this.singlePubkeyRegisteredListener
-            );
-            this.accountRegistry.removeListener(
-                this.batchPubkeyRegisteredFilter,
-                this.batchPubkeyRegisteredListener
-            );
         }
     }
 }

--- a/ts/client/services/syncer.ts
+++ b/ts/client/services/syncer.ts
@@ -5,6 +5,7 @@ import { NewBatchEventSyncer } from "./events/newBatch";
 import { SequentialCompositeEventSyncer } from "./events/sequentialCompositeEventSyncer";
 import { BatchPubkeyRegisteredEventSyncer } from "./events/batchPubkeyRegistered";
 import { SinglePubkeyRegisteredEventSyncer } from "./events/singlePubkeyRegistered";
+import { DepositQueuedEventSyncer } from "./events/depositQueued";
 
 export enum SyncMode {
     INITIAL_SYNCING,
@@ -23,6 +24,7 @@ export class SyncerService {
             // Pubkey syncs need to happen before batch syncs, etc.
             new SinglePubkeyRegisteredEventSyncer(api),
             new BatchPubkeyRegisteredEventSyncer(api),
+            new DepositQueuedEventSyncer(api),
             new NewBatchEventSyncer(api)
         ]);
     }

--- a/ts/client/storageEngine/memoryEngine.ts
+++ b/ts/client/storageEngine/memoryEngine.ts
@@ -74,6 +74,7 @@ export class MemoryEngine<Item extends Hashable>
         this.cache = {};
     }
 
+    // These will be implemented in https://github.com/thehubbleproject/hubble-contracts/issues/570
     public async findVacantSubtree(
         subtreeDepth: number
     ): Promise<{ path: number; witness: string[] }> {

--- a/ts/commitments.ts
+++ b/ts/commitments.ts
@@ -245,22 +245,22 @@ export class Batch {
         return this.tree.root;
     }
 
-    witness(leafInfex: number): string[] {
-        return this.tree.witness(leafInfex).nodes;
+    witness(leafIndex: number): string[] {
+        return this.tree.witness(leafIndex).nodes;
     }
 
-    proof(leafInfex: number): XCommitmentInclusionProof {
+    proof(leafIndex: number): XCommitmentInclusionProof {
         return {
-            commitment: this.commitments[leafInfex].toSolStruct(),
-            path: leafInfex,
-            witness: this.witness(leafInfex)
+            commitment: this.commitments[leafIndex].toSolStruct(),
+            path: leafIndex,
+            witness: this.witness(leafIndex)
         };
     }
-    proofCompressed(leafInfex: number): CommitmentInclusionProof {
+    proofCompressed(leafIndex: number): CommitmentInclusionProof {
         return {
-            commitment: this.commitments[leafInfex].toCompressedStruct(),
-            path: leafInfex,
-            witness: this.witness(leafInfex)
+            commitment: this.commitments[leafIndex].toCompressedStruct(),
+            path: leafIndex,
+            witness: this.witness(leafIndex)
         };
     }
 }

--- a/ts/state.ts
+++ b/ts/state.ts
@@ -1,4 +1,4 @@
-import { BigNumber, BigNumberish, ethers } from "ethers";
+import { BigNumber, BigNumberish, ethers, Event } from "ethers";
 import { BytesLike, solidityPack } from "ethers/lib/utils";
 import { Hashable } from "./interfaces";
 
@@ -12,7 +12,7 @@ export class State implements Hashable {
         return new State(pubkeyID, tokenID, BigNumber.from(balance), nonce);
     }
 
-    static fromEncoded(data: BytesLike) {
+    static fromEncoded(data: BytesLike): State {
         const [
             pubkeyID,
             tokenID,
@@ -23,6 +23,14 @@ export class State implements Hashable {
             data
         );
         return new this(pubkeyID, tokenID, balance, nonce);
+    }
+
+    static fromDepositQueuedEvent(event: Event): State {
+        if (!event.args) {
+            throw new Error("DepositQueued event missing args");
+        }
+        const { pubkeyID, tokenID, l2Amount } = event.args;
+        return State.new(pubkeyID.toNumber(), tokenID.toNumber(), l2Amount, 0);
     }
 
     public clone() {
@@ -61,6 +69,12 @@ export class State implements Hashable {
             balance,
             nonce
         };
+    }
+    public toString(): string {
+        const propsStr = Object.entries(this.toJSON())
+            .map(([k, v]) => `${k} ${v}`)
+            .join(" ");
+        return `<State  ${propsStr}>`;
     }
 }
 


### PR DESCRIPTION
- Add `EventSyncer` interface to abstract and separate out logic that syncs L1 event to L2.
- Implement `DepositQueued` event syncing.
- Typo fixes and other minor cleanup.

~TODO~
- [x] Move `singlePubkeyRegistered`, `batchPubkeyRegistered` to `EventSyncer` pattern.
- [x] Implement event syncing for `DepositQueued`, `DepositFinalized` events.
~Complete sync integration test, implement `MemoryEngine.updateBatch`.~ https://github.com/thehubbleproject/hubble-contracts/issues/570