### PR TITLE
Make mass migration tx type consistent with batch type

### DIFF
--- a/contracts/libs/Tx.sol
+++ b/contracts/libs/Tx.sol
@@ -14,8 +14,8 @@ import { BLS } from "./BLS.sol";
 library Tx {
     // Tx types in uint256
     uint256 private constant TRANSFER = 1;
+    uint256 private constant MASS_MIGRATION = 2;
     uint256 private constant CREATE2TRANSFER = 3;
-    uint256 private constant MASS_MIGRATION = 5;
 
     uint256 public constant MASK_PUBKEY_ID = 0xffffffff;
     uint256 public constant MASK_STATE_ID = 0xffffffff;

--- a/ts/tx.ts
+++ b/ts/tx.ts
@@ -145,7 +145,7 @@ export class TxTransfer implements SignableTx {
 }
 
 export class TxMassMigration implements SignableTx {
-    private readonly TX_TYPE = "0x05";
+    private readonly TX_TYPE = "0x02";
     public static rand(): TxMassMigration {
         const sender = randomNum(stateIDLen);
         const amount = float16.randInt();


### PR DESCRIPTION
`Transfer` and `Create2Transfer` transaction types are consistent with their corresponding bach types (`1`  for `Transfer` and `3` for `Create2Transfer`) while `MassMigration` types are inconsistent i.e., the transaction type is set to `5` while the batch type is set to `2`. 

This PR modifies the `MassMigration` transaction type so it corresponds to its batch type.