### PR TITLE
Modify TokenRegistry contract

### DIFF
--- a/contracts/TokenRegistry.sol
+++ b/contracts/TokenRegistry.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.6.12;
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 interface ITokenRegistry {
-    event RegisteredToken(uint256 tokenID, address tokenContract);
+    event TokenRegistered(uint256 tokenID, address tokenContract);
 
     function safeGetRecord(uint256 tokenID)
         external
@@ -59,7 +59,7 @@ contract TokenRegistry is ITokenRegistry {
         });
         registeredContracts[tokenContract] = true;
 
-        emit RegisteredToken(nextTokenID, tokenContract);
+        emit TokenRegistered(nextTokenID, tokenContract);
         nextTokenID++;
     }
 }

--- a/contracts/TokenRegistry.sol
+++ b/contracts/TokenRegistry.sol
@@ -6,9 +6,9 @@ interface ITokenRegistry {
     event RegisteredToken(uint256 tokenID, address tokenContract);
 
     function safeGetRecord(uint256 tokenID)
-    external
-    view
-    returns (address, uint256 l2Unit);
+        external
+        view
+        returns (address, uint256 l2Unit);
 
     function registerToken(address tokenContract) external;
 }
@@ -44,7 +44,7 @@ contract TokenRegistry is ITokenRegistry {
 
     function registerToken(address tokenContract) public override {
         require(
-            registeredContracts[tokenContract],
+            !registeredContracts[tokenContract],
             "Token already registered."
         );
         require(

--- a/scripts/tokens.ts
+++ b/scripts/tokens.ts
@@ -62,23 +62,14 @@ async function registerToken(
     tokenAddress: string
 ): Promise<BigNumber> {
     console.log(`  registering token at ${tokenAddress}`);
-    const requestL1Txn = await tokenRegistry.requestRegistration(tokenAddress);
-    console.log("    token registration request sent", requestL1Txn.hash);
-    await requestL1Txn.wait(1);
-    console.log("    token registration request confirmed", requestL1Txn.hash);
+    const registerL1Txn = await tokenRegistry.registerToken(tokenAddress);
+    console.log("    token registration sent", registerL1Txn.hash);
+    const txnReceipt = await registerL1Txn.wait(1);
+    console.log("    token registration confirmed", registerL1Txn.hash);
 
-    const finaliseL1Txn = await tokenRegistry.finaliseRegistration(
-        tokenAddress
-    );
-    console.log("    token registration finalisation sent", finaliseL1Txn.hash);
-    const finaliseTxnReceipt = await finaliseL1Txn.wait(1);
-    console.log(
-        "    token registration finalisation confirmed",
-        finaliseL1Txn.hash
-    );
-    const [registeredTokenLog] = finaliseTxnReceipt.logs
+    const [registeredTokenLog] = txnReceipt.logs
         .map(log => tokenRegistry.interface.parseLog(log))
-        .filter(log => log.signature === "RegisteredToken(uint256,address)");
+        .filter(log => log.signature === "TokenRegistered(uint256,address)");
     return registeredTokenLog.args.tokenID;
 }
 

--- a/test/client/integration.test.ts
+++ b/test/client/integration.test.ts
@@ -67,8 +67,7 @@ describe("Client Integration", function() {
             new CustomToken__factory(signer).deploy("Telescope", "TLSC")
         ]);
         for (const token of customTokens) {
-            await contracts.tokenRegistry.requestRegistration(token.address);
-            await contracts.tokenRegistry.finaliseRegistration(token.address);
+            await contracts.tokenRegistry.registerToken(token.address);
         }
         const allTokens = [contracts.exampleToken, ...customTokens];
 

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -95,7 +95,7 @@ describe("Integration Test", function() {
         );
         const tx = await tokenRegistry.registerToken(newToken.address);
         const [event] = await tokenRegistry.queryFilter(
-            tokenRegistry.filters.RegisteredToken(null, null),
+            tokenRegistry.filters.TokenRegistered(null, null),
             tx.blockHash
         );
 

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -93,8 +93,7 @@ describe("Integration Test", function() {
             "FreshCoin",
             "FRSH"
         );
-        await tokenRegistry.requestRegistration(newToken.address);
-        const tx = await tokenRegistry.finaliseRegistration(newToken.address);
+        const tx = await tokenRegistry.registerToken(newToken.address);
         const [event] = await tokenRegistry.queryFilter(
             tokenRegistry.filters.RegisteredToken(null, null),
             tx.blockHash

--- a/ts/deploy.ts
+++ b/ts/deploy.ts
@@ -102,10 +102,7 @@ export async function deployAll(
     );
     await waitAndRegister(exampleToken, "exampleToken", verbose);
     await waitUntilMined(
-        tokenRegistry.requestRegistration(exampleToken.address)
-    );
-    await waitUntilMined(
-        tokenRegistry.finaliseRegistration(exampleToken.address)
+        tokenRegistry.registerToken(exampleToken.address)
     );
 
     const spokeRegistry = await new SpokeRegistry__factory(signer).deploy();

--- a/ts/deploy.ts
+++ b/ts/deploy.ts
@@ -101,9 +101,7 @@ export async function deployAll(
         "EMP"
     );
     await waitAndRegister(exampleToken, "exampleToken", verbose);
-    await waitUntilMined(
-        tokenRegistry.registerToken(exampleToken.address)
-    );
+    await waitUntilMined(tokenRegistry.registerToken(exampleToken.address));
 
     const spokeRegistry = await new SpokeRegistry__factory(signer).deploy();
     await waitAndRegister(spokeRegistry, "spokeRegistry", verbose);


### PR DESCRIPTION
Simplify registration to one tx instead of two and prevent registering the same token twice.