### PR TITLE
Pass correct result on dispute invalid post state root 

### DIFF
--- a/contracts/Create2Transfer.sol
+++ b/contracts/Create2Transfer.sol
@@ -22,8 +22,8 @@ contract Create2Transfer {
      * @notice processes the state transition of a commitment
      * */
     function processCreate2TransferCommit(
+        bytes32 currentStateRoot,
         bytes32 postStateRoot,
-        bytes32 previousStateRoot,
         uint256 maxTxSize,
         uint256 feeReceiver,
         bytes memory txs,
@@ -41,8 +41,8 @@ contract Create2Transfer {
 
         for (uint256 i = 0; i < size; i++) {
             _tx = txs.create2TransferDecode(i);
-            (previousStateRoot, result) = Transition.processCreate2Transfer(
-                previousStateRoot,
+            (currentStateRoot, result) = Transition.processCreate2Transfer(
+                currentStateRoot,
                 _tx,
                 tokenID,
                 proofs[i * 2],
@@ -52,8 +52,8 @@ contract Create2Transfer {
             // Only trust fees when the result is good
             fees = fees.add(_tx.fee);
         }
-        (previousStateRoot, result) = Transition.processReceiver(
-            previousStateRoot,
+        (currentStateRoot, result) = Transition.processReceiver(
+            currentStateRoot,
             feeReceiver,
             tokenID,
             fees,
@@ -61,7 +61,7 @@ contract Create2Transfer {
         );
 
         if (result != Types.Result.Ok) return result;
-        if (previousStateRoot != postStateRoot)
+        if (currentStateRoot != postStateRoot)
             return Types.Result.InvalidPostStateRoot;
         return result;
     }

--- a/contracts/Create2Transfer.sol
+++ b/contracts/Create2Transfer.sol
@@ -22,16 +22,17 @@ contract Create2Transfer {
      * @notice processes the state transition of a commitment
      * */
     function processCreate2TransferCommit(
-        bytes32 stateRoot,
+        bytes32 postStateRoot,
+        bytes32 previousStateRoot,
         uint256 maxTxSize,
         uint256 feeReceiver,
         bytes memory txs,
         Types.StateMerkleProof[] memory proofs
-    ) public pure returns (bytes32, Types.Result result) {
+    ) public pure returns (Types.Result result) {
         if (txs.create2TransferHasExcessData())
-            return (stateRoot, Types.Result.BadCompression);
+            return Types.Result.BadCompression;
         uint256 size = txs.create2TransferSize();
-        if (size > maxTxSize) return (stateRoot, Types.Result.TooManyTx);
+        if (size > maxTxSize) return Types.Result.TooManyTx;
 
         uint256 fees = 0;
         // tokenID should be the same for all states in this commit
@@ -40,25 +41,28 @@ contract Create2Transfer {
 
         for (uint256 i = 0; i < size; i++) {
             _tx = txs.create2TransferDecode(i);
-            (stateRoot, result) = Transition.processCreate2Transfer(
-                stateRoot,
+            (previousStateRoot, result) = Transition.processCreate2Transfer(
+                previousStateRoot,
                 _tx,
                 tokenID,
                 proofs[i * 2],
                 proofs[i * 2 + 1]
             );
-            if (result != Types.Result.Ok) return (stateRoot, result);
+            if (result != Types.Result.Ok) return result;
             // Only trust fees when the result is good
             fees = fees.add(_tx.fee);
         }
-        (stateRoot, result) = Transition.processReceiver(
-            stateRoot,
+        (previousStateRoot, result) = Transition.processReceiver(
+            previousStateRoot,
             feeReceiver,
             tokenID,
             fees,
             proofs[size * 2]
         );
 
-        return (stateRoot, result);
+        if (result != Types.Result.Ok) return result;
+        if (previousStateRoot != postStateRoot)
+            return Types.Result.InvalidPostStateRoot;
+        return result;
     }
 }

--- a/contracts/MassMigrations.sol
+++ b/contracts/MassMigrations.sol
@@ -23,19 +23,20 @@ contract MassMigration {
 
     /**
      * @notice processes the state transition of a commitment
-     * @param stateRoot represents the state before the state transition
+     * @param previousStateRoot represents the state before the state transition
      * */
     function processMassMigrationCommit(
-        bytes32 stateRoot,
+        bytes32 postStateRoot,
+        bytes32 previousStateRoot,
         uint256 maxTxSize,
         Types.MassMigrationBody memory committed,
         Types.StateMerkleProof[] memory proofs
-    ) public pure returns (bytes32, Types.Result result) {
+    ) public pure returns (Types.Result result) {
         if (committed.txs.massMigrationHasExcessData())
-            return (stateRoot, Types.Result.BadCompression);
+            return Types.Result.BadCompression;
 
         uint256 size = committed.txs.massMigrationSize();
-        if (size > maxTxSize) return (stateRoot, Types.Result.TooManyTx);
+        if (size > maxTxSize) return Types.Result.TooManyTx;
 
         Tx.MassMigration memory _tx;
         uint256 totalAmount = 0;
@@ -45,34 +46,38 @@ contract MassMigration {
 
         for (uint256 i = 0; i < size; i++) {
             _tx = committed.txs.massMigrationDecode(i);
-            (stateRoot, freshState, result) = Transition.processMassMigration(
-                stateRoot,
+            (previousStateRoot, freshState, result) = Transition
+                .processMassMigration(
+                previousStateRoot,
                 _tx,
                 committed.tokenID,
                 proofs[i]
             );
-            if (result != Types.Result.Ok) return (stateRoot, result);
+            if (result != Types.Result.Ok) return result;
 
             // Only trust these variables when the result is good
             totalAmount += _tx.amount;
             fees += _tx.fee;
             withdrawLeaves[i] = keccak256(freshState);
         }
-        (stateRoot, result) = Transition.processReceiver(
-            stateRoot,
+        (previousStateRoot, result) = Transition.processReceiver(
+            previousStateRoot,
             committed.feeReceiver,
             committed.tokenID,
             fees,
             proofs[size]
         );
-        if (result != Types.Result.Ok) return (stateRoot, result);
+        if (result != Types.Result.Ok) return result;
 
         if (totalAmount != committed.amount)
-            return (stateRoot, Types.Result.MismatchedAmount);
+            return Types.Result.MismatchedAmount;
 
         if (MerkleTree.merklize(withdrawLeaves) != committed.withdrawRoot)
-            return (stateRoot, Types.Result.BadWithdrawRoot);
+            return Types.Result.BadWithdrawRoot;
 
-        return (stateRoot, result);
+        if (previousStateRoot != postStateRoot)
+            return Types.Result.InvalidPostStateRoot;
+
+        return result;
     }
 }

--- a/contracts/Transfer.sol
+++ b/contracts/Transfer.sol
@@ -23,8 +23,8 @@ contract Transfer {
      * @notice processes the state transition of a commitment
      * */
     function processTransferCommit(
+        bytes32 currentStateRoot,
         bytes32 postStateRoot,
-        bytes32 previousStateRoot,
         uint256 maxTxSize,
         uint256 feeReceiver,
         bytes memory txs,
@@ -42,8 +42,8 @@ contract Transfer {
 
         for (uint256 i = 0; i < size; i++) {
             _tx = txs.transferDecode(i);
-            (previousStateRoot, result) = Transition.processTransfer(
-                previousStateRoot,
+            (currentStateRoot, result) = Transition.processTransfer(
+                currentStateRoot,
                 _tx,
                 tokenID,
                 proofs[i * 2],
@@ -53,8 +53,8 @@ contract Transfer {
             // Only trust fees when the result is good
             fees = fees.add(_tx.fee);
         }
-        (previousStateRoot, result) = Transition.processReceiver(
-            previousStateRoot,
+        (currentStateRoot, result) = Transition.processReceiver(
+            currentStateRoot,
             feeReceiver,
             tokenID,
             fees,
@@ -62,7 +62,7 @@ contract Transfer {
         );
 
         if (result != Types.Result.Ok) return result;
-        if (previousStateRoot != postStateRoot)
+        if (currentStateRoot != postStateRoot)
             return Types.Result.InvalidPostStateRoot;
         return result;
     }

--- a/contracts/libs/Types.sol
+++ b/contracts/libs/Types.sol
@@ -251,6 +251,7 @@ library Types {
         BadCompression,
         TooManyTx,
         BadPrecompileCall,
-        NonexistentReceiver
+        NonexistentReceiver,
+        InvalidPostStateRoot
     }
 }

--- a/contracts/rollup/Rollup.sol
+++ b/contracts/rollup/Rollup.sol
@@ -377,8 +377,9 @@ contract Rollup is BatchManager, EIP712, IEIP712 {
             "Target commitment is absent in the batch"
         );
 
-        (bytes32 processedStateRoot, Types.Result result) =
+        Types.Result result =
             transfer.processTransferCommit(
+                target.commitment.stateRoot,
                 previous.commitment.stateRoot,
                 paramMaxTxsPerCommit,
                 target.commitment.body.feeReceiver,
@@ -386,10 +387,7 @@ contract Rollup is BatchManager, EIP712, IEIP712 {
                 proofs
             );
 
-        if (
-            result != Types.Result.Ok ||
-            (processedStateRoot != target.commitment.stateRoot)
-        ) startRollingBack(batchID, result);
+        if (result != Types.Result.Ok) startRollingBack(batchID, result);
     }
 
     function disputeTransitionMassMigration(
@@ -407,18 +405,16 @@ contract Rollup is BatchManager, EIP712, IEIP712 {
             "Target commitment is absent in the batch"
         );
 
-        (bytes32 processedStateRoot, Types.Result result) =
+        Types.Result result =
             massMigration.processMassMigrationCommit(
+                target.commitment.stateRoot,
                 previous.commitment.stateRoot,
                 paramMaxTxsPerCommit,
                 target.commitment.body,
                 proofs
             );
 
-        if (
-            result != Types.Result.Ok ||
-            (processedStateRoot != target.commitment.stateRoot)
-        ) startRollingBack(batchID, result);
+        if (result != Types.Result.Ok) startRollingBack(batchID, result);
     }
 
     function disputeTransitionCreate2Transfer(
@@ -436,8 +432,9 @@ contract Rollup is BatchManager, EIP712, IEIP712 {
             "Target commitment is absent in the batch"
         );
 
-        (bytes32 processedStateRoot, Types.Result result) =
+        Types.Result result =
             create2Transfer.processCreate2TransferCommit(
+                target.commitment.stateRoot,
                 previous.commitment.stateRoot,
                 paramMaxTxsPerCommit,
                 target.commitment.body.feeReceiver,
@@ -445,10 +442,7 @@ contract Rollup is BatchManager, EIP712, IEIP712 {
                 proofs
             );
 
-        if (
-            result != Types.Result.Ok ||
-            (processedStateRoot != target.commitment.stateRoot)
-        ) startRollingBack(batchID, result);
+        if (result != Types.Result.Ok) startRollingBack(batchID, result);
     }
 
     function disputeSignatureTransfer(

--- a/contracts/rollup/Rollup.sol
+++ b/contracts/rollup/Rollup.sol
@@ -379,8 +379,8 @@ contract Rollup is BatchManager, EIP712, IEIP712 {
 
         Types.Result result =
             transfer.processTransferCommit(
-                target.commitment.stateRoot,
                 previous.commitment.stateRoot,
+                target.commitment.stateRoot,
                 paramMaxTxsPerCommit,
                 target.commitment.body.feeReceiver,
                 target.commitment.body.txs,
@@ -407,8 +407,8 @@ contract Rollup is BatchManager, EIP712, IEIP712 {
 
         Types.Result result =
             massMigration.processMassMigrationCommit(
-                target.commitment.stateRoot,
                 previous.commitment.stateRoot,
+                target.commitment.stateRoot,
                 paramMaxTxsPerCommit,
                 target.commitment.body,
                 proofs
@@ -434,8 +434,8 @@ contract Rollup is BatchManager, EIP712, IEIP712 {
 
         Types.Result result =
             create2Transfer.processCreate2TransferCommit(
-                target.commitment.stateRoot,
                 previous.commitment.stateRoot,
+                target.commitment.stateRoot,
                 paramMaxTxsPerCommit,
                 target.commitment.body.feeReceiver,
                 target.commitment.body.txs,

--- a/contracts/test/TestCreate2Transfer.sol
+++ b/contracts/test/TestCreate2Transfer.sol
@@ -47,21 +47,23 @@ contract TestCreate2Transfer is Create2Transfer {
     }
 
     function testProcessCreate2TransferCommit(
-        bytes32 stateRoot,
+        bytes32 postStateRoot,
+        bytes32 previousStateRoot,
         uint256 maxTxSize,
         uint256 feeReceiver,
         bytes memory txs,
         Types.StateMerkleProof[] memory proofs
-    ) public returns (bytes32, uint256) {
-        bytes32 newRoot;
-        uint256 operationCost = gasleft();
-        (newRoot, ) = processCreate2TransferCommit(
-            stateRoot,
-            maxTxSize,
-            feeReceiver,
-            txs,
-            proofs
-        );
-        return (newRoot, operationCost - gasleft());
+    ) public returns (uint256 gasCost, Types.Result) {
+        gasCost = gasleft();
+        Types.Result result =
+            processCreate2TransferCommit(
+                postStateRoot,
+                previousStateRoot,
+                maxTxSize,
+                feeReceiver,
+                txs,
+                proofs
+            );
+        return (gasCost - gasleft(), result);
     }
 }

--- a/contracts/test/TestCreate2Transfer.sol
+++ b/contracts/test/TestCreate2Transfer.sol
@@ -47,8 +47,8 @@ contract TestCreate2Transfer is Create2Transfer {
     }
 
     function testProcessCreate2TransferCommit(
+        bytes32 currentStateRoot,
         bytes32 postStateRoot,
-        bytes32 previousStateRoot,
         uint256 maxTxSize,
         uint256 feeReceiver,
         bytes memory txs,
@@ -57,8 +57,8 @@ contract TestCreate2Transfer is Create2Transfer {
         gasCost = gasleft();
         Types.Result result =
             processCreate2TransferCommit(
+                currentStateRoot,
                 postStateRoot,
-                previousStateRoot,
                 maxTxSize,
                 feeReceiver,
                 txs,

--- a/contracts/test/TestMassMigration.sol
+++ b/contracts/test/TestMassMigration.sol
@@ -29,27 +29,21 @@ contract TestMassMigration is MassMigration {
     }
 
     function testProcessMassMigrationCommit(
-        bytes32 stateRoot,
+        bytes32 postStateRoot,
+        bytes32 previousStateRoot,
         uint256 maxTxSize,
         Types.MassMigrationBody memory commitmentBody,
         Types.StateMerkleProof[] memory proofs
-    )
-        public
-        view
-        returns (
-            uint256 gasCost,
-            bytes32,
-            Types.Result
-        )
-    {
+    ) public view returns (uint256 gasCost, Types.Result) {
         gasCost = gasleft();
-        (bytes32 postRoot, Types.Result result) =
+        Types.Result result =
             processMassMigrationCommit(
-                stateRoot,
+                postStateRoot,
+                previousStateRoot,
                 maxTxSize,
                 commitmentBody,
                 proofs
             );
-        return (gasCost - gasleft(), postRoot, result);
+        return (gasCost - gasleft(), result);
     }
 }

--- a/contracts/test/TestMassMigration.sol
+++ b/contracts/test/TestMassMigration.sol
@@ -29,8 +29,8 @@ contract TestMassMigration is MassMigration {
     }
 
     function testProcessMassMigrationCommit(
+        bytes32 currentStateRoot,
         bytes32 postStateRoot,
-        bytes32 previousStateRoot,
         uint256 maxTxSize,
         Types.MassMigrationBody memory commitmentBody,
         Types.StateMerkleProof[] memory proofs
@@ -38,8 +38,8 @@ contract TestMassMigration is MassMigration {
         gasCost = gasleft();
         Types.Result result =
             processMassMigrationCommit(
+                currentStateRoot,
                 postStateRoot,
-                previousStateRoot,
                 maxTxSize,
                 commitmentBody,
                 proofs

--- a/contracts/test/TestTransfer.sol
+++ b/contracts/test/TestTransfer.sol
@@ -40,8 +40,8 @@ contract TestTransfer is Transfer {
     }
 
     function testProcessTransferCommit(
+        bytes32 currentStateRoot,
         bytes32 postStateRoot,
-        bytes32 previousStateRoot,
         uint256 maxTxSize,
         uint256 feeReceiver,
         bytes memory txs,
@@ -50,8 +50,8 @@ contract TestTransfer is Transfer {
         gasCost = gasleft();
         Types.Result result =
             processTransferCommit(
+                currentStateRoot,
                 postStateRoot,
-                previousStateRoot,
                 maxTxSize,
                 feeReceiver,
                 txs,

--- a/contracts/test/TestTransfer.sol
+++ b/contracts/test/TestTransfer.sol
@@ -40,21 +40,23 @@ contract TestTransfer is Transfer {
     }
 
     function testProcessTransferCommit(
-        bytes32 stateRoot,
+        bytes32 postStateRoot,
+        bytes32 previousStateRoot,
         uint256 maxTxSize,
         uint256 feeReceiver,
         bytes memory txs,
         Types.StateMerkleProof[] memory proofs
-    ) public returns (bytes32, uint256) {
-        bytes32 newRoot;
-        uint256 operationCost = gasleft();
-        (newRoot, ) = processTransferCommit(
-            stateRoot,
-            maxTxSize,
-            feeReceiver,
-            txs,
-            proofs
-        );
-        return (newRoot, operationCost - gasleft());
+    ) public returns (uint256 gasCost, Types.Result) {
+        gasCost = gasleft();
+        Types.Result result =
+            processTransferCommit(
+                postStateRoot,
+                previousStateRoot,
+                maxTxSize,
+                feeReceiver,
+                txs,
+                proofs
+            );
+        return (gasCost - gasleft(), result);
     }
 }

--- a/test/slow/commit.create2transfer.test.ts
+++ b/test/slow/commit.create2transfer.test.ts
@@ -11,8 +11,12 @@ import { assert } from "chai";
 import { ethers } from "hardhat";
 import { hexToUint8Array, randHex } from "../../ts/utils";
 import { Result } from "../../ts/interfaces";
-import {Group, txCreate2TransferFactory, txTransferFactory} from "../../ts/factory";
-import {COMMIT_SIZE, STATE_TREE_DEPTH} from "../../ts/constants";
+import {
+    Group,
+    txCreate2TransferFactory,
+    txTransferFactory
+} from "../../ts/factory";
+import { COMMIT_SIZE, STATE_TREE_DEPTH } from "../../ts/constants";
 import { deployKeyless } from "../../ts/deployment/deploy";
 import { hashPubkey } from "../../ts/pubkey";
 import { BigNumber } from "ethers";
@@ -220,7 +224,10 @@ describe("Rollup Create2Transfer Commitment", () => {
         const feeReceiver = 0;
 
         const preStateRoot = stateTree.root;
-        const { proofs } = stateTree.processCreate2TransferCommit(txs, feeReceiver);
+        const { proofs } = stateTree.processCreate2TransferCommit(
+            txs,
+            feeReceiver
+        );
 
         const [
             gasCost,
@@ -233,7 +240,14 @@ describe("Rollup Create2Transfer Commitment", () => {
             serialize(txs),
             proofs
         );
-        console.log("processCreate2TransferCommit gas cost", gasCost.toNumber());
-        assert.equal(result, Result.InvalidPostStateRoot, `Got ${Result[result]}`);
+        console.log(
+            "processCreate2TransferCommit gas cost",
+            gasCost.toNumber()
+        );
+        assert.equal(
+            result,
+            Result.InvalidPostStateRoot,
+            `Got ${Result[result]}`
+        );
     }).timeout(80000);
 });

--- a/test/slow/commit.massMigration.test.ts
+++ b/test/slow/commit.massMigration.test.ts
@@ -79,10 +79,7 @@ describe("Rollup Mass Migration", () => {
             pubkeys,
             pubkeyWitnesses
         };
-        const {
-            0: gasCost,
-            1: result
-        } = await rollup.callStatic.testCheckSignature(
+        const [gasCost, result] = await rollup.callStatic.testCheckSignature(
             signature,
             proof,
             postStateRoot,
@@ -123,10 +120,7 @@ describe("Rollup Mass Migration", () => {
             pubkeys,
             pubkeyWitnesses
         };
-        const {
-            0: gasCost,
-            1: result
-        } = await rollup.callStatic.testCheckSignature(
+        const [gasCost, result] = await rollup.callStatic.testCheckSignature(
             signature,
             proof,
             postStateRoot,
@@ -157,18 +151,17 @@ describe("Rollup Mass Migration", () => {
             stateTree
         );
 
-        const {
-            0: gasCost,
-            1: postRoot,
-            2: result
-        } = await rollup.callStatic.testProcessMassMigrationCommit(
+        const [
+            gasCost,
+            result
+        ] = await rollup.callStatic.testProcessMassMigrationCommit(
+            postStateRoot,
             preStateRoot,
             COMMIT_SIZE,
             commitment.toSolStruct().body,
             proofs
         );
         console.log("processTransferBatch gas cost", gasCost.toNumber());
-        assert.equal(postRoot, postStateRoot, "Mismatch post state root");
-        assert.equal(Result[result], Result[Result.Ok]);
+        assert.equal(result, Result.Ok, `Got ${Result[result]}`);
     }).timeout(80000);
 });

--- a/test/slow/commit.massMigration.test.ts
+++ b/test/slow/commit.massMigration.test.ts
@@ -193,6 +193,10 @@ describe("Rollup Mass Migration", () => {
             proofs
         );
         console.log("processMassMigrationCommit gas cost", gasCost.toNumber());
-        assert.equal(result, Result.InvalidPostStateRoot, `Got ${Result[result]}`);
+        assert.equal(
+            result,
+            Result.InvalidPostStateRoot,
+            `Got ${Result[result]}`
+        );
     }).timeout(80000);
 });

--- a/test/slow/commit.massMigration.test.ts
+++ b/test/slow/commit.massMigration.test.ts
@@ -155,8 +155,8 @@ describe("Rollup Mass Migration", () => {
             gasCost,
             result
         ] = await rollup.callStatic.testProcessMassMigrationCommit(
-            postStateRoot,
             preStateRoot,
+            postStateRoot,
             COMMIT_SIZE,
             commitment.toSolStruct().body,
             proofs

--- a/test/slow/commit.massMigration.test.ts
+++ b/test/slow/commit.massMigration.test.ts
@@ -161,7 +161,38 @@ describe("Rollup Mass Migration", () => {
             commitment.toSolStruct().body,
             proofs
         );
-        console.log("processTransferBatch gas cost", gasCost.toNumber());
+        console.log("processMassMigrationCommit gas cost", gasCost.toNumber());
         assert.equal(result, Result.Ok, `Got ${Result[result]}`);
+    }).timeout(80000);
+
+    it("returns invalid post state root result", async function() {
+        const { txs } = txMassMigrationFactory(users, spokeID);
+        const feeReceiver = 0;
+
+        const preStateRoot = stateTree.root;
+        const { proofs } = stateTree.processMassMigrationCommit(
+            txs,
+            feeReceiver
+        );
+        const { commitment } = MassMigrationCommitment.fromStateProvider(
+            constants.HashZero,
+            txs,
+            EMPTY_SIGNATURE,
+            feeReceiver,
+            stateTree
+        );
+
+        const [
+            gasCost,
+            result
+        ] = await rollup.callStatic.testProcessMassMigrationCommit(
+            preStateRoot,
+            preStateRoot,
+            COMMIT_SIZE,
+            commitment.toSolStruct().body,
+            proofs
+        );
+        console.log("processMassMigrationCommit gas cost", gasCost.toNumber());
+        assert.equal(result, Result.InvalidPostStateRoot, `Got ${Result[result]}`);
     }).timeout(80000);
 });

--- a/test/slow/commit.transfer.test.ts
+++ b/test/slow/commit.transfer.test.ts
@@ -206,6 +206,10 @@ describe("Rollup Transfer Commitment", () => {
             proofs
         );
         console.log("processTransferCommit gas cost", gasCost.toNumber());
-        assert.equal(result, Result.InvalidPostStateRoot, `Got ${Result[result]}`);
+        assert.equal(
+            result,
+            Result.InvalidPostStateRoot,
+            `Got ${Result[result]}`
+        );
     }).timeout(80000);
 });

--- a/test/slow/commit.transfer.test.ts
+++ b/test/slow/commit.transfer.test.ts
@@ -176,8 +176,8 @@ describe("Rollup Transfer Commitment", () => {
             gasCost,
             result
         ] = await rollup.callStatic.testProcessTransferCommit(
-            postStateRoot,
             preStateRoot,
+            postStateRoot,
             COMMIT_SIZE,
             feeReceiver,
             serialize(txs),

--- a/test/slow/commit.transfer.test.ts
+++ b/test/slow/commit.transfer.test.ts
@@ -183,7 +183,29 @@ describe("Rollup Transfer Commitment", () => {
             serialize(txs),
             proofs
         );
-        console.log("processTransferBatch gas cost", gasCost.toNumber());
+        console.log("processTransferCommit gas cost", gasCost.toNumber());
         assert.equal(result, Result.Ok, `Got ${Result[result]}`);
+    }).timeout(80000);
+
+    it("returns invalid post state root result", async function() {
+        const { txs } = txTransferFactory(users, COMMIT_SIZE);
+        const feeReceiver = 0;
+
+        const preStateRoot = stateTree.root;
+        const { proofs } = stateTree.processTransferCommit(txs, feeReceiver);
+
+        const [
+            gasCost,
+            result
+        ] = await rollup.callStatic.testProcessTransferCommit(
+            preStateRoot,
+            preStateRoot,
+            COMMIT_SIZE,
+            feeReceiver,
+            serialize(txs),
+            proofs
+        );
+        console.log("processTransferCommit gas cost", gasCost.toNumber());
+        assert.equal(result, Result.InvalidPostStateRoot, `Got ${Result[result]}`);
     }).timeout(80000);
 });

--- a/test/slow/commit.transfer.test.ts
+++ b/test/slow/commit.transfer.test.ts
@@ -129,10 +129,7 @@ describe("Rollup Transfer Commitment", () => {
             pubkeys,
             pubkeyWitnesses
         };
-        const {
-            0: gasCost,
-            1: result
-        } = await rollup.callStatic._checkSignature(
+        const [gasCost, result] = await rollup.callStatic._checkSignature(
             signature,
             proof,
             stateTree.root,
@@ -152,10 +149,7 @@ describe("Rollup Transfer Commitment", () => {
                 tokenID
             );
             const postRoot = stateTree.root;
-            const {
-                0: processedRoot,
-                1: result
-            } = await rollup.testProcessTransfer(
+            const [processedRoot, result] = await rollup.testProcessTransfer(
                 preRoot,
                 tx,
                 tokenID,
@@ -178,10 +172,11 @@ describe("Rollup Transfer Commitment", () => {
         const { proofs } = stateTree.processTransferCommit(txs, feeReceiver);
         const postStateRoot = stateTree.root;
 
-        const {
-            0: postRoot,
-            1: gasCost
-        } = await rollup.callStatic.testProcessTransferCommit(
+        const [
+            gasCost,
+            result
+        ] = await rollup.callStatic.testProcessTransferCommit(
+            postStateRoot,
             preStateRoot,
             COMMIT_SIZE,
             feeReceiver,
@@ -189,6 +184,6 @@ describe("Rollup Transfer Commitment", () => {
             proofs
         );
         console.log("processTransferBatch gas cost", gasCost.toNumber());
-        assert.equal(postRoot, postStateRoot, "Mismatch post state root");
+        assert.equal(result, Result.Ok, `Got ${Result[result]}`);
     }).timeout(80000);
 });

--- a/test/slow/rollup.massMigration.test.ts
+++ b/test/slow/rollup.massMigration.test.ts
@@ -101,21 +101,14 @@ describe("Mass Migrations", async function() {
             feeReceiver,
             stateTree
         );
-        const {
-            0: processedStateRoot,
-            1: result
-        } = await massMigration.processMassMigrationCommit(
+        const result = await massMigration.processMassMigrationCommit(
+            postStateRoot,
             preStateRoot,
             TESTING_PARAMS.MAX_TXS_PER_COMMIT,
             commitment.toSolStruct().body,
             proofs
         );
-        assert.equal(Result[result], Result[Result.Ok]);
-        assert.equal(
-            processedStateRoot,
-            postStateRoot,
-            "should have same state root"
-        );
+        assert.equal(result, Result.Ok, `Got ${Result[result]}`);
 
         const targetBatch = commitment.toBatch();
         const mMBatchID = 1;

--- a/test/slow/rollup.massMigration.test.ts
+++ b/test/slow/rollup.massMigration.test.ts
@@ -102,8 +102,8 @@ describe("Mass Migrations", async function() {
             stateTree
         );
         const result = await massMigration.processMassMigrationCommit(
-            postStateRoot,
             preStateRoot,
+            postStateRoot,
             TESTING_PARAMS.MAX_TXS_PER_COMMIT,
             commitment.toSolStruct().body,
             proofs

--- a/ts/interfaces.ts
+++ b/ts/interfaces.ts
@@ -18,7 +18,8 @@ export enum Result {
     BadCompression,
     TooManyTx,
     BadPrecompileCall,
-    NonexistentReceiver
+    NonexistentReceiver,
+    InvalidPostStateRoot
 }
 
 export type Wei = string;


### PR DESCRIPTION
It would be nice to emit `RollbackTriggered` with correct result when rollback is triggered by invalid post state root(right now  it's `Types.Result.Ok`).

I added simple if statement in dispute functions, but I can change `processCommit` function for each batch type to accept additional `postStateRoot` as argument and return only `Types.Result` instead of postStateRoot and result.
What do you think? @jacque006 